### PR TITLE
fix(pages): set base via VITE_BASE env var so it reaches vite build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -82,7 +82,7 @@ jobs:
           pnpm install --frozen-lockfile
           # Stage OpenAPI specs into public/api/ (servers block from SCL_API_BASE_URL if set).
           node scripts/prepare-openapi.mjs
-          pnpm build --base="${PAGES_BASE}"
+          VITE_BASE="${PAGES_BASE}" pnpm build
 
       - uses: actions/configure-pages@v5
         with:

--- a/external-docs/vite.config.ts
+++ b/external-docs/vite.config.ts
@@ -8,7 +8,11 @@ import { resolve } from 'node:path'
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
-  base: './',
+  // Absolute base so asset URLs resolve correctly regardless of the serving
+  // path (GitHub Pages project subpath vs. local dev/preview at '/'). Override
+  // via the VITE_BASE env var — the pages.yml workflow sets this to
+  // PAGES_BASE ("/context-ontology-accelerator/") for the production build.
+  base: process.env.VITE_BASE ?? '/',
   build: {
     outDir: 'dist',
   },


### PR DESCRIPTION
pnpm build --base=... doesn't thread the flag through the compound 'tsc -b && vite build' script, so vite silently kept the default base ('./' relative), producing asset URLs that 404-fallback to HTML under GitHub Pages' project-subpath serving (NS_ERROR_CORRUPTED_CONTENT / MIME mismatch in the browser).

vite.config.ts now reads base from process.env.VITE_BASE (default '/'), and the workflow sets VITE_BASE instead of passing --base.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
