### PR TITLE
Fix 13 issues: ontology/R2RML correctness, authorization scoping, and infra reliability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ deploy-serve:
 ## deletes VKG's ECS services, force-deletes the DataZone domain (cascades
 ## to RETAINed child resources CFN can't clear on its own), then runs
 ## `cdk destroy --all` and verifies no stacks remain (see #660, #661, #707).
-## Optional env vars: SCL_PREFIX (default: scl), SCL_DESTROY_YES=1 to skip
+## Optional env vars: SCL_PREFIX (default: coa — matches the CDK app), SCL_DESTROY_YES=1 to skip
 ## the confirmation prompt (e.g. in CI), SCL_ENI_WAIT_MAX_SECONDS (default
 ## 600), SCL_ECS_WAIT_MAX_SECONDS (default 300), and
 ## SCL_DOMAIN_WAIT_MAX_SECONDS (default 300) to tune wait budgets.

--- a/infra/lib/constructs/lakeformation-admin.ts
+++ b/infra/lib/constructs/lakeformation-admin.ts
@@ -11,6 +11,16 @@ import { Construct } from "constructs";
 export interface LakeFormationAdminProps {
   /** SSM parameter name holding the IAM role ARN to register as an LF data-lake admin. */
   readonly roleArnSsmParameterName: string;
+  /**
+   * The role ARN the SSM parameter resolves to.
+   *
+   * Passed as a custom-resource property purely so a change to the *value*
+   * produces a property diff. With only the parameter *name* as a property, a
+   * deployment that repointed the parameter at a different role left the custom
+   * resource untouched (no diff → no Update → the new role never registered);
+   * the handler still reads the authoritative value from SSM at runtime.
+   */
+  readonly roleArn: string;
 }
 
 /**
@@ -71,7 +81,13 @@ export class LakeFormationAdmin extends Construct {
     });
     new cdk.CustomResource(this, "Resource", {
       serviceToken: provider.serviceToken,
-      properties: { RoleArnSsmParameterName: props.roleArnSsmParameterName },
+      properties: {
+        RoleArnSsmParameterName: props.roleArnSsmParameterName,
+        // Value-carrying property so repointing the parameter triggers an
+        // Update — see LakeFormationAdminProps.roleArn. The handler reads the
+        // authoritative ARN from SSM; this is only a change detector.
+        RoleArn: props.roleArn,
+      },
     });
   }
 }

--- a/infra/lib/constructs/scl-stack.ts
+++ b/infra/lib/constructs/scl-stack.ts
@@ -9,7 +9,7 @@ import { resolveContext, prefixed } from "../context";
  * Base stack for all SemanticContext CloudFormation stacks.
  *
  * ## CDK Context Variables
- *   - `resource_prefix` (default: `"scl"`)
+ *   - `resource_prefix` (default: `DEFAULT_RESOURCE_PREFIX`, i.e. `"coa"`)
  *   - `env`             (default: `"dev"`)
  *   - `project_tag`     (default: `"semantic-context"`)
  *   - `vpc_id`          (optional, on NetworkStack - import existing VPC)

--- a/infra/lib/lambdas/lakeformation-admin/index.py
+++ b/infra/lib/lambdas/lakeformation-admin/index.py
@@ -3,16 +3,21 @@
 
 """Custom resource — non-destructively registers an IAM role as an LF data-lake admin.
 
-Reads the target role ARN from SSM, then GetDataLakeSettings -> append the role
-to DataLakeAdmins if absent -> PutDataLakeSettings (full settings object), so
-existing admins and other settings are preserved. Removes the role on Delete
-(best-effort, so it never blocks stack teardown). Returns the
-Provider-framework OnEventResponse shape.
+On Create/Update: reads the target role ARN from SSM, then GetDataLakeSettings ->
+append the role to DataLakeAdmins if absent -> PutDataLakeSettings (full settings
+object), so existing admins and other settings are preserved.
+
+On Delete: removes the role recorded in this physical resource's own
+``PhysicalResourceId`` (``lf-admin-{arn}``) — deliberately NOT the current SSM
+value, which under CloudFormation replacement semantics points at the *new* role
+by the time the old resource's cleanup Delete arrives. Best-effort, so an LF
+error never blocks stack teardown, but failures are logged.
+
+Returns the Provider-framework OnEventResponse shape.
 """
 
 from __future__ import annotations
 
-import contextlib
 import re
 
 import boto3
@@ -28,16 +33,14 @@ _sts = boto3.client("sts")
 _ROLE_ARN_RE = re.compile(r"^arn:aws[a-z-]*:iam::(\d{12}):role/.+")
 
 
-def _target(event: dict) -> str:
-    """Resolve and validate the target role ARN from the SSM parameter."""
-    name = event["ResourceProperties"]["RoleArnSsmParameterName"]
-    try:
-        arn = _ssm.get_parameter(Name=name)["Parameter"]["Value"]
-    except ClientError as e:
-        raise ValueError(f"Failed to read SSM parameter {name!r}: {e}") from e
+_PHYSICAL_ID_PREFIX = "lf-admin-"
+
+
+def _validate(arn: str, source: str) -> str:
+    """Validate ``arn`` is a same-account IAM role ARN, or raise."""
     m = _ROLE_ARN_RE.match(arn or "")
     if not m:
-        raise ValueError(f"SSM parameter {name!r} is not an IAM role ARN: {arn!r}")
+        raise ValueError(f"{source} is not an IAM role ARN: {arn!r}")
     try:
         account = _sts.get_caller_identity()["Account"]
     except ClientError as e:
@@ -45,6 +48,46 @@ def _target(event: dict) -> str:
     if m.group(1) != account:
         raise ValueError(f"Refusing to register cross-account principal as LF admin: {arn!r}")
     return arn
+
+
+def _target(event: dict) -> str:
+    """Resolve and validate the target role ARN from the SSM parameter."""
+    name = event["ResourceProperties"]["RoleArnSsmParameterName"]
+    try:
+        arn = _ssm.get_parameter(Name=name)["Parameter"]["Value"]
+    except ClientError as e:
+        raise ValueError(f"Failed to read SSM parameter {name!r}: {e}") from e
+    return _validate(arn, f"SSM parameter {name!r}")
+
+
+def _delete_target(event: dict) -> str | None:
+    """Resolve the ARN this physical resource registered, from its own id.
+
+    Delete MUST deregister the principal *this* physical resource created, which
+    is encoded in ``PhysicalResourceId`` (``lf-admin-{arn}``) — NOT whatever the
+    SSM parameter happens to point at now. When an update changes the role ARN,
+    CloudFormation creates the new physical resource first and then sends a
+    cleanup Delete for the OLD id; resolving from SSM at that point returns the
+    NEW arn, so the handler deregistered the role it had just registered and left
+    the stale one in place. Every LF-privileged operation downstream (federated
+    catalog creation during JDBC scans, LF-governed catalog teardown) then failed
+    with authorization errors unrelated-looking to the deploy — and
+    ``contextlib.suppress`` in the caller hid it while the deployment reported
+    success.
+
+    Returns ``None`` when the id carries no ARN (the ``"lf-admin"`` fallback a
+    failed Create returns, or a resource created before the id carried the ARN),
+    in which case there is nothing safe to deregister and Delete is a no-op.
+    """
+    physical_id = event.get("PhysicalResourceId") or ""
+    if not physical_id.startswith(_PHYSICAL_ID_PREFIX):
+        return None
+    arn = physical_id[len(_PHYSICAL_ID_PREFIX) :]
+    if not arn:
+        return None
+    # Still validate: the id is round-tripped through CloudFormation, and this
+    # keeps the cross-account guard on the deregister path too.
+    return _validate(arn, f"PhysicalResourceId {physical_id!r}")
 
 
 def _apply(request_type: str, target: str) -> None:
@@ -85,10 +128,17 @@ def handler(event: dict, context: object = None) -> dict:
         ``PhysicalResourceId``.
     """
     if event["RequestType"] == "Delete":
-        # Best-effort: never block stack deletion on an LF error.
-        with contextlib.suppress(Exception):
-            _apply("Delete", _target(event))
+        # Deregister the principal recorded in THIS physical resource's id, not
+        # the current SSM value — see _delete_target. Best-effort: never block
+        # stack deletion on an LF error, but log it, since a swallowed failure
+        # here is how a stale admin silently survives a teardown.
+        try:
+            target = _delete_target(event)
+            if target is not None:
+                _apply("Delete", target)
+        except Exception as e:  # noqa: BLE001 - deliberately non-fatal
+            print(f"WARNING: failed to deregister LF admin on Delete: {type(e).__name__}: {e}")
         return {"PhysicalResourceId": event.get("PhysicalResourceId", "lf-admin")}
     target = _target(event)
     _apply(event["RequestType"], target)
-    return {"PhysicalResourceId": f"lf-admin-{target}"}
+    return {"PhysicalResourceId": f"{_PHYSICAL_ID_PREFIX}{target}"}

--- a/infra/lib/stacks/services/sources-stack.ts
+++ b/infra/lib/stacks/services/sources-stack.ts
@@ -723,6 +723,7 @@ export class SourcesStack extends SCLStack {
       "FederationProvisionerLfAdmin",
       {
         roleArnSsmParameterName: `${ssmPrefix}/sources/federation-provisioner-role-arn`,
+        roleArn: fedFnRole.roleArn,
       },
     );
     lfAdmin.node.addDependency(fedRoleArnParam);

--- a/infra/lib/utils/python-bundling.ts
+++ b/infra/lib/utils/python-bundling.ts
@@ -75,8 +75,10 @@ function resolvePipCommand(): string {
  * ```
  */
 export function bundlePython(opts: PythonBundlingOptions): lambda.Code {
-  // Compute a stable hash from only the files that matter for this Lambda.
-  const assetHash = _computeSourceHash(opts.srcDirs, opts.requirementsFile);
+  // Compute a stable hash over EVERY input that affects the produced bundle.
+  // Omitting one means CDK reuses a stale cached asset and the Lambda keeps
+  // running old code or old dependencies, with no error at deploy time.
+  const assetHash = _computeSourceHash(opts);
 
   // Normalize all source paths to forward slashes for Docker compatibility
   const srcDirs = opts.srcDirs.map((d) => d.replace(/\\/g, "/"));
@@ -94,10 +96,15 @@ export function bundlePython(opts: PythonBundlingOptions): lambda.Code {
     "s3transfer",
     "jmespath",
   ];
+  // Anchor the dist-info glob on the version separator (`-`) so it cannot match a
+  // DIFFERENT package that merely starts with the same name: `boto3*dist-info`
+  // also matched `boto3_stubs-1.2.3.dist-info`, deleting that package's metadata
+  // while leaving its code in place — a half-removed install. A real dist-info is
+  // always `{name}-{version}.dist-info`.
   const cleanup = runtimePkgs
     .map(
       (p) =>
-        `rm -rf /asset-output/${p} /asset-output/${p.replace("-", "_")}*dist-info`,
+        `rm -rf /asset-output/${p} /asset-output/${p.replace("-", "_")}-*.dist-info`,
     )
     .join(" && ");
 
@@ -157,58 +164,87 @@ function escapeRegExp(s: string): string {
 }
 
 /**
- * Compute a stable SHA-256 hash from only the source files and requirements
- * that actually affect this Lambda bundle. Used as a custom CDK asset hash
- * so that unrelated repo changes (test outputs, coverage files, etc.) don't
- * trigger unnecessary re-bundles.
+ * Compute a stable SHA-256 hash over every input that affects this Lambda
+ * bundle. Used as a custom CDK asset hash so unrelated repo changes (test
+ * outputs, coverage files, …) don't trigger needless re-bundles.
  *
- * On Linux/macOS: uses `find | sort | xargs sha256sum` (preserves existing hashes).
- * On Windows: uses Node.js fs (quiet, no shell noise).
+ * Hashes ALL files under `srcDirs` — not just `*.py`. The bundle command copies
+ * everything (`cp -r ${d}/*`), so JSON/schema/template files shipped alongside
+ * the code are part of the output and must invalidate the asset when edited.
+ *
+ * Also folds in `pipDeps` and `architecture`, which change the produced bundle
+ * without touching any file:
+ *   - `pipDeps` is the alternative to `requirementsFile`; callers using it could
+ *     add, remove, or re-pin a dependency with no hash change, so the deployed
+ *     bundle kept the old dependency set (symptom: `ImportModuleError` for a
+ *     freshly added dep).
+ *   - `architecture` selects the pip `--platform` tag and therefore which binary
+ *     wheels land in the bundle, so flipping x86_64 ↔ arm64 reused an asset built
+ *     for the wrong architecture.
+ *
+ * Reads files via Node on every platform. The previous `find … || true` shell
+ * pipeline was unquoted and failure-suppressed, so a repo path containing a space
+ * degraded every hash to the empty-input hash — permanently disabling
+ * invalidation — and any `find` failure passed silently.
  */
-function _computeSourceHash(
-  srcDirs: string[],
-  requirementsFile?: string,
-): string {
+export function _computeSourceHash(opts: PythonBundlingOptions): string {
   const hash = crypto.createHash("sha256");
-  for (const dir of srcDirs) {
-    try {
-      if (process.platform === "win32") {
-        const normalizedDir = dir.replace(/\\/g, "/");
-        const files = _collectPyFiles(normalizedDir).sort();
-        for (const file of files) {
-          const fileHash = crypto
-            .createHash("sha256")
-            .update(fs.readFileSync(file))
-            .digest("hex");
-          hash.update(`${fileHash}  ${file}\n`);
-        }
-      } else {
-        const out = execSync(
-          `find ${dir} -type f -name "*.py" | sort | xargs sha256sum 2>/dev/null || true`,
-          { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
-        );
-        hash.update(out);
-      }
-    } catch {
-      // Directory may not exist yet — ignore
+
+  // Bundle-shaping inputs first, so they are covered even if a srcDir is absent.
+  hash.update(`architecture:${opts.architecture ?? "x86_64"}\n`);
+  if (opts.pipDeps?.length) {
+    // Sorted: dependency ORDER does not change the installed set, so it must not
+    // change the hash (an unsorted list would cause spurious re-bundles).
+    hash.update(`pipDeps:${[...opts.pipDeps].sort().join(",")}\n`);
+  }
+
+  for (const dir of opts.srcDirs) {
+    const normalizedDir = dir.replace(/\\/g, "/");
+    if (!fs.existsSync(normalizedDir)) {
+      // A source dir that does not exist yet still has to affect the hash, or
+      // creating it later would not invalidate the asset.
+      hash.update(`missing:${normalizedDir}\n`);
+      continue;
+    }
+    for (const file of _collectFiles(normalizedDir).sort()) {
+      const fileHash = crypto
+        .createHash("sha256")
+        .update(fs.readFileSync(file))
+        .digest("hex");
+      // Path is included so a rename alone invalidates the asset.
+      hash.update(`${fileHash}  ${file}\n`);
     }
   }
-  if (requirementsFile && fs.existsSync(requirementsFile)) {
-    hash.update(fs.readFileSync(requirementsFile));
+
+  if (opts.requirementsFile) {
+    if (fs.existsSync(opts.requirementsFile)) {
+      hash.update(fs.readFileSync(opts.requirementsFile));
+    } else {
+      hash.update(`missing:${opts.requirementsFile}\n`);
+    }
   }
   return hash.digest("hex");
 }
 
-/** Recursively collect all .py file paths in a directory. */
-function _collectPyFiles(dir: string): string[] {
+/**
+ * Recursively collect every file path in a directory.
+ *
+ * Deliberately NOT limited to `*.py`: the bundle copies the whole tree, so any
+ * non-Python file it ships (JSON, schemas, templates, Cedar policies) must
+ * invalidate the asset when edited.
+ *
+ * `__pycache__` is skipped — it is build output, not input, and hashing it would
+ * make the asset depend on whether tests happened to run first.
+ */
+function _collectFiles(dir: string): string[] {
   if (!fs.existsSync(dir)) return [];
   const results: string[] = [];
-  const entries = fs.readdirSync(dir, { withFileTypes: true });
-  for (const entry of entries) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const fullPath = `${dir}/${entry.name}`;
     if (entry.isDirectory()) {
-      results.push(..._collectPyFiles(fullPath));
-    } else if (entry.isFile() && entry.name.endsWith(".py")) {
+      if (entry.name === "__pycache__") continue;
+      results.push(..._collectFiles(fullPath));
+    } else if (entry.isFile() && !entry.name.endsWith(".pyc")) {
       results.push(fullPath);
     }
   }

--- a/infra/test/lambdas/conftest.py
+++ b/infra/test/lambdas/conftest.py
@@ -1,16 +1,54 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared fixtures for VKG reload Lambda tests.
+"""Shared fixtures for the infra Lambda handler tests.
 
 Patch the boto3 factory to mock the cloudwatch client so it survives the in-test
 `importlib.reload(index)` and never makes real PutMetricData calls.
+
+Adding a test for another Lambda handler here
+-----------------------------------------------
+Every handler in this repo is named ``index.py``. Importing one by its bare
+module name registers it as ``sys.modules["index"]``, so two such test modules
+in this directory fight over that one slot: whichever imports last wins, and
+``@patch("index.<attr>")`` in the other module then resolves against the wrong
+handler and raises ``AttributeError`` — only when the files run together, which
+makes it look like a flaky, order-dependent failure.
+
+``test_vkg_reload_handler.py`` owns the bare ``index`` name (it patches
+``index.ecs`` / ``index.sd`` / ``index.ssm`` in ~19 places). Any NEW handler test
+must load its module under a unique name instead of touching ``sys.path`` — see
+``test_lakeformation_admin_handler.py`` for the ``spec_from_file_location``
+pattern.
 """
 
+import sys
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import boto3
 import pytest
+
+_VKG_RELOAD_DIR = Path(__file__).resolve().parents[2] / "lambda" / "vkg-reload"
+
+
+@pytest.fixture(autouse=True)
+def _guard_index_module_identity():
+    """Fail loudly if ``sys.modules["index"]`` is not the vkg-reload handler.
+
+    Turns the order-dependent ``AttributeError`` described in the module
+    docstring into an explicit, self-explaining failure at the point of
+    contamination, instead of a confusing patch error in an unrelated test.
+    """
+    yield
+    module = sys.modules.get("index")
+    origin = getattr(module, "__file__", None)
+    if origin is not None and Path(origin).parent != _VKG_RELOAD_DIR:
+        pytest.fail(
+            f'sys.modules["index"] is {origin}, not the vkg-reload handler. '
+            "A handler test imported its index.py by bare module name — load it under a "
+            "unique name instead (see this directory's conftest docstring)."
+        )
 
 
 @pytest.fixture(autouse=True)

--- a/infra/test/lambdas/test_lakeformation_admin_handler.py
+++ b/infra/test/lambdas/test_lakeformation_admin_handler.py
@@ -10,14 +10,22 @@ Delete carrying the OLD PhysicalResourceId. Resolving the target from SSM at tha
 point yields the NEW arn, so the handler deregisters the role it just registered.
 """
 
-import importlib
+import importlib.util
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
-_HANDLER_DIR = Path(__file__).resolve().parents[2] / "lib" / "lambdas" / "lakeformation-admin"
+_HANDLER_PATH = Path(__file__).resolve().parents[2] / "lib" / "lambdas" / "lakeformation-admin" / "index.py"
+
+# Every Lambda handler in this repo is named ``index.py``, so importing them by
+# bare module name makes them collide in ``sys.modules["index"]``: whichever test
+# module imports last wins, and ``@patch("index.<attr>")`` in the other one then
+# targets the wrong module (AttributeError). Load this handler under a unique
+# module name via an explicit spec so it never participates in that race — and
+# never mutate ``sys.path``.
+_MODULE_NAME = "lakeformation_admin_index_under_test"
 
 ACCOUNT = "111122223333"
 ROLE_A = f"arn:aws:iam::{ACCOUNT}:role/provisioner-a"
@@ -27,13 +35,13 @@ PARAM = "/coa/sources/federation-provisioner-role-arn"
 
 @pytest.fixture
 def index(monkeypatch):
-    """Import the handler with its module-level boto3 clients stubbed out."""
-    sys.path.insert(0, str(_HANDLER_DIR))
-    try:
-        mod = importlib.import_module("index")
-        mod = importlib.reload(mod)
-    finally:
-        sys.path.remove(str(_HANDLER_DIR))
+    """Import the handler under a unique module name, with boto3 clients stubbed."""
+    spec = importlib.util.spec_from_file_location(_MODULE_NAME, _HANDLER_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[_MODULE_NAME] = mod
+    monkeypatch.delitem(sys.modules, _MODULE_NAME, raising=False)
+    spec.loader.exec_module(mod)
 
     monkeypatch.setattr(mod, "_ssm", MagicMock())
     monkeypatch.setattr(mod, "_lf", MagicMock())

--- a/infra/test/lambdas/test_lakeformation_admin_handler.py
+++ b/infra/test/lambdas/test_lakeformation_admin_handler.py
@@ -1,0 +1,187 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the LakeFormationAdmin custom-resource handler.
+
+The behaviour under test is which principal a Delete deregisters. CloudFormation
+replacement semantics make this subtle: when an Update changes the role ARN, the
+new physical resource is created first and CloudFormation then sends a cleanup
+Delete carrying the OLD PhysicalResourceId. Resolving the target from SSM at that
+point yields the NEW arn, so the handler deregisters the role it just registered.
+"""
+
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_HANDLER_DIR = Path(__file__).resolve().parents[2] / "lib" / "lambdas" / "lakeformation-admin"
+
+ACCOUNT = "111122223333"
+ROLE_A = f"arn:aws:iam::{ACCOUNT}:role/provisioner-a"
+ROLE_B = f"arn:aws:iam::{ACCOUNT}:role/provisioner-b"
+PARAM = "/coa/sources/federation-provisioner-role-arn"
+
+
+@pytest.fixture
+def index(monkeypatch):
+    """Import the handler with its module-level boto3 clients stubbed out."""
+    sys.path.insert(0, str(_HANDLER_DIR))
+    try:
+        mod = importlib.import_module("index")
+        mod = importlib.reload(mod)
+    finally:
+        sys.path.remove(str(_HANDLER_DIR))
+
+    monkeypatch.setattr(mod, "_ssm", MagicMock())
+    monkeypatch.setattr(mod, "_lf", MagicMock())
+    monkeypatch.setattr(mod, "_sts", MagicMock())
+    mod._sts.get_caller_identity.return_value = {"Account": ACCOUNT}
+    return mod
+
+
+def _ssm_returns(index, arn):
+    index._ssm.get_parameter.return_value = {"Parameter": {"Value": arn}}
+
+
+def _lf_admins(index, *arns):
+    index._lf.get_data_lake_settings.return_value = {
+        "DataLakeSettings": {"DataLakeAdmins": [{"DataLakePrincipalIdentifier": a} for a in arns]}
+    }
+
+
+def _written_admins(index):
+    """Return the principals from the last PutDataLakeSettings call."""
+    settings = index._lf.put_data_lake_settings.call_args.kwargs["DataLakeSettings"]
+    return [a["DataLakePrincipalIdentifier"] for a in settings["DataLakeAdmins"]]
+
+
+def _event(request_type, *, physical_id=None):
+    event = {
+        "RequestType": request_type,
+        "ResourceProperties": {"RoleArnSsmParameterName": PARAM, "RoleArn": ROLE_B},
+    }
+    if physical_id is not None:
+        event["PhysicalResourceId"] = physical_id
+    return event
+
+
+class TestCreate:
+    def test_appends_role_and_encodes_it_in_physical_id(self, index):
+        _ssm_returns(index, ROLE_A)
+        _lf_admins(index, "arn:aws:iam::111122223333:role/existing")
+
+        result = index.handler(_event("Create"))
+
+        assert result["PhysicalResourceId"] == f"lf-admin-{ROLE_A}"
+        assert ROLE_A in _written_admins(index)
+
+    def test_preserves_existing_admins(self, index):
+        existing = f"arn:aws:iam::{ACCOUNT}:role/existing"
+        _ssm_returns(index, ROLE_A)
+        _lf_admins(index, existing)
+
+        index.handler(_event("Create"))
+
+        assert existing in _written_admins(index)
+
+    def test_is_idempotent_when_already_admin(self, index):
+        _ssm_returns(index, ROLE_A)
+        _lf_admins(index, ROLE_A)
+
+        index.handler(_event("Create"))
+
+        assert _written_admins(index).count(ROLE_A) == 1
+
+
+class TestDeleteTargetsThePhysicalResource:
+    """Delete must deregister its OWN principal, not the current SSM value."""
+
+    def test_replacement_cleanup_removes_the_old_role_not_the_new_one(self, index):
+        # An Update repointed the parameter from A to B and registered B. CFN now
+        # sends the cleanup Delete for the OLD physical resource, lf-admin-A.
+        _ssm_returns(index, ROLE_B)
+        _lf_admins(index, ROLE_A, ROLE_B)
+
+        index.handler(_event("Delete", physical_id=f"lf-admin-{ROLE_A}"))
+
+        remaining = _written_admins(index)
+        assert ROLE_B in remaining, "deregistered the newly-registered role"
+        assert ROLE_A not in remaining, "left the stale role registered"
+
+    def test_delete_does_not_read_ssm(self, index):
+        _lf_admins(index, ROLE_A)
+
+        index.handler(_event("Delete", physical_id=f"lf-admin-{ROLE_A}"))
+
+        index._ssm.get_parameter.assert_not_called()
+
+    def test_normal_teardown_removes_the_role(self, index):
+        other = f"arn:aws:iam::{ACCOUNT}:role/other-admin"
+        _lf_admins(index, ROLE_A, other)
+
+        index.handler(_event("Delete", physical_id=f"lf-admin-{ROLE_A}"))
+
+        remaining = _written_admins(index)
+        assert ROLE_A not in remaining
+        assert other in remaining, "clobbered an unrelated admin"
+
+
+class TestDeleteEdgeCases:
+    def test_no_op_when_physical_id_carries_no_arn(self, index):
+        """A failed Create returns the bare "lf-admin" sentinel — nothing to remove."""
+        index.handler(_event("Delete", physical_id="lf-admin"))
+
+        index._lf.put_data_lake_settings.assert_not_called()
+
+    def test_no_op_when_physical_id_is_absent(self, index):
+        index.handler(_event("Delete"))
+
+        index._lf.put_data_lake_settings.assert_not_called()
+
+    def test_no_op_for_unrecognized_physical_id(self, index):
+        index.handler(_event("Delete", physical_id="some-other-resource"))
+
+        index._lf.put_data_lake_settings.assert_not_called()
+
+    def test_lf_error_never_blocks_teardown(self, index):
+        _lf_admins(index, ROLE_A)
+        index._lf.put_data_lake_settings.side_effect = RuntimeError("LF unavailable")
+
+        result = index.handler(_event("Delete", physical_id=f"lf-admin-{ROLE_A}"))
+
+        assert result["PhysicalResourceId"] == f"lf-admin-{ROLE_A}"
+
+    def test_cross_account_arn_in_physical_id_is_refused(self, index):
+        """The cross-account guard applies on the deregister path too."""
+        foreign = "arn:aws:iam::999988887777:role/attacker"
+        _lf_admins(index, foreign)
+
+        index.handler(_event("Delete", physical_id=f"lf-admin-{foreign}"))
+
+        index._lf.put_data_lake_settings.assert_not_called()
+
+
+class TestTargetValidation:
+    def test_rejects_non_role_arn_from_ssm(self, index):
+        _ssm_returns(index, f"arn:aws:iam::{ACCOUNT}:user/not-a-role")
+
+        with pytest.raises(ValueError, match="not an IAM role ARN"):
+            index.handler(_event("Create"))
+
+    def test_rejects_cross_account_role(self, index):
+        _ssm_returns(index, "arn:aws:iam::999988887777:role/foreign")
+
+        with pytest.raises(ValueError, match="cross-account"):
+            index.handler(_event("Create"))
+
+    def test_create_failure_propagates(self, index):
+        """A failed registration must fail the deployment, not silently pass."""
+        _ssm_returns(index, ROLE_A)
+        _lf_admins(index, ROLE_A)
+        index._lf.put_data_lake_settings.side_effect = RuntimeError("boom")
+
+        with pytest.raises(RuntimeError):
+            index.handler(_event("Create"))

--- a/infra/test/utils/python-bundling.test.ts
+++ b/infra/test/utils/python-bundling.test.ts
@@ -1,0 +1,223 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { _computeSourceHash } from "../../lib/utils/python-bundling";
+
+/**
+ * The asset hash is what CDK uses to decide whether to re-bundle. Any input that
+ * changes the produced bundle but NOT the hash means a stale cached asset is
+ * silently reused — the Lambda keeps running old code or old dependencies with no
+ * error at deploy time.
+ */
+describe("bundlePython asset hash", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "coa-bundle-hash-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  /** Create a src dir with the given relative files, return its absolute path. */
+  function srcDir(name: string, files: Record<string, string>): string {
+    const dir = path.join(root, name);
+    for (const [rel, content] of Object.entries(files)) {
+      const full = path.join(dir, rel);
+      fs.mkdirSync(path.dirname(full), { recursive: true });
+      fs.writeFileSync(full, content);
+    }
+    fs.mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  describe("source files", () => {
+    it("changes when a .py file changes", () => {
+      const dir = srcDir("a", { "mod.py": "x = 1" });
+      const before = _computeSourceHash({ srcDirs: [dir] });
+
+      fs.writeFileSync(path.join(dir, "mod.py"), "x = 2");
+
+      expect(_computeSourceHash({ srcDirs: [dir] })).not.toEqual(before);
+    });
+
+    it("changes when a NON-.py file changes", () => {
+      // The bundle copies everything (`cp -r ${d}/*`), so a schema/JSON file
+      // shipped alongside the code is part of the output.
+      const dir = srcDir("a", { "mod.py": "x = 1", "schema.json": '{"v":1}' });
+      const before = _computeSourceHash({ srcDirs: [dir] });
+
+      fs.writeFileSync(path.join(dir, "schema.json"), '{"v":2}');
+
+      expect(_computeSourceHash({ srcDirs: [dir] })).not.toEqual(before);
+    });
+
+    it("changes when a nested file changes", () => {
+      const dir = srcDir("a", { "pkg/sub/mod.py": "x = 1" });
+      const before = _computeSourceHash({ srcDirs: [dir] });
+
+      fs.writeFileSync(path.join(dir, "pkg/sub/mod.py"), "x = 2");
+
+      expect(_computeSourceHash({ srcDirs: [dir] })).not.toEqual(before);
+    });
+
+    it("changes when a file is renamed but content is identical", () => {
+      const dir = srcDir("a", { "old.py": "x = 1" });
+      const before = _computeSourceHash({ srcDirs: [dir] });
+
+      fs.renameSync(path.join(dir, "old.py"), path.join(dir, "new.py"));
+
+      expect(_computeSourceHash({ srcDirs: [dir] })).not.toEqual(before);
+    });
+
+    it("is stable across calls with no changes", () => {
+      const dir = srcDir("a", { "mod.py": "x = 1", "data.json": "{}" });
+
+      expect(_computeSourceHash({ srcDirs: [dir] })).toEqual(
+        _computeSourceHash({ srcDirs: [dir] }),
+      );
+    });
+
+    it("ignores __pycache__ so a prior test run cannot change the hash", () => {
+      const dir = srcDir("a", { "mod.py": "x = 1" });
+      const before = _computeSourceHash({ srcDirs: [dir] });
+
+      fs.mkdirSync(path.join(dir, "__pycache__"), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, "__pycache__/mod.cpython-312.pyc"),
+        "\x00",
+      );
+
+      expect(_computeSourceHash({ srcDirs: [dir] })).toEqual(before);
+    });
+
+    it("handles a path containing spaces", () => {
+      // The old shell pipeline was unquoted and failure-suppressed (`|| true`),
+      // so a path with a space degraded every hash to the empty-input hash —
+      // permanently disabling invalidation.
+      const dir = srcDir("dir with space", { "mod.py": "x = 1" });
+      const before = _computeSourceHash({ srcDirs: [dir] });
+
+      fs.writeFileSync(path.join(dir, "mod.py"), "x = 2");
+      const after = _computeSourceHash({ srcDirs: [dir] });
+
+      expect(after).not.toEqual(before);
+      expect(before).not.toEqual(_computeSourceHash({ srcDirs: [] }));
+    });
+
+    it("distinguishes a missing src dir from an empty one", () => {
+      const missing = path.join(root, "not-created");
+      const empty = srcDir("empty", {});
+
+      expect(_computeSourceHash({ srcDirs: [missing] })).not.toEqual(
+        _computeSourceHash({ srcDirs: [empty] }),
+      );
+    });
+  });
+
+  describe("pipDeps", () => {
+    it("changes when a dependency is added", () => {
+      const dir = srcDir("a", { "mod.py": "x = 1" });
+      const before = _computeSourceHash({
+        srcDirs: [dir],
+        pipDeps: ["pydantic"],
+      });
+
+      const after = _computeSourceHash({
+        srcDirs: [dir],
+        pipDeps: ["pydantic", "structlog"],
+      });
+
+      expect(after).not.toEqual(before);
+    });
+
+    it("changes when a dependency is removed", () => {
+      const dir = srcDir("a", { "mod.py": "x = 1" });
+      const before = _computeSourceHash({
+        srcDirs: [dir],
+        pipDeps: ["pydantic", "structlog"],
+      });
+
+      expect(
+        _computeSourceHash({ srcDirs: [dir], pipDeps: ["pydantic"] }),
+      ).not.toEqual(before);
+    });
+
+    it("changes when a dependency is re-pinned", () => {
+      const dir = srcDir("a", { "mod.py": "x = 1" });
+      const before = _computeSourceHash({
+        srcDirs: [dir],
+        pipDeps: ["pydantic==2.1.0"],
+      });
+
+      expect(
+        _computeSourceHash({ srcDirs: [dir], pipDeps: ["pydantic==2.2.0"] }),
+      ).not.toEqual(before);
+    });
+
+    it("does NOT change when only the order differs", () => {
+      // Order does not change the installed set, so it must not cause a re-bundle.
+      const dir = srcDir("a", { "mod.py": "x = 1" });
+
+      expect(
+        _computeSourceHash({ srcDirs: [dir], pipDeps: ["a", "b"] }),
+      ).toEqual(_computeSourceHash({ srcDirs: [dir], pipDeps: ["b", "a"] }));
+    });
+  });
+
+  describe("architecture", () => {
+    it("changes between x86_64 and arm64", () => {
+      // Selects the pip --platform tag, and therefore which binary wheels are in
+      // the bundle. Reusing an asset across architectures ships wrong wheels.
+      const dir = srcDir("a", { "mod.py": "x = 1" });
+
+      expect(
+        _computeSourceHash({ srcDirs: [dir], architecture: "arm64" }),
+      ).not.toEqual(
+        _computeSourceHash({ srcDirs: [dir], architecture: "x86_64" }),
+      );
+    });
+
+    it("treats an omitted architecture as the x86_64 default", () => {
+      const dir = srcDir("a", { "mod.py": "x = 1" });
+
+      expect(_computeSourceHash({ srcDirs: [dir] })).toEqual(
+        _computeSourceHash({ srcDirs: [dir], architecture: "x86_64" }),
+      );
+    });
+  });
+
+  describe("requirementsFile", () => {
+    it("changes when the requirements content changes", () => {
+      const dir = srcDir("a", { "mod.py": "x = 1" });
+      const req = path.join(root, "requirements.txt");
+      fs.writeFileSync(req, "pydantic==2.1.0\n");
+      const before = _computeSourceHash({
+        srcDirs: [dir],
+        requirementsFile: req,
+      });
+
+      fs.writeFileSync(req, "pydantic==2.2.0\n");
+
+      expect(
+        _computeSourceHash({ srcDirs: [dir], requirementsFile: req }),
+      ).not.toEqual(before);
+    });
+
+    it("distinguishes a missing requirements file from none at all", () => {
+      const dir = srcDir("a", { "mod.py": "x = 1" });
+
+      expect(
+        _computeSourceHash({
+          srcDirs: [dir],
+          requirementsFile: path.join(root, "absent.txt"),
+        }),
+      ).not.toEqual(_computeSourceHash({ srcDirs: [dir] }));
+    });
+  });
+});

--- a/libs/common/src/coa_common/dao/base.py
+++ b/libs/common/src/coa_common/dao/base.py
@@ -81,6 +81,49 @@ class DatastoreDAO(ABC):
     def query(self, params: QueryParams) -> PaginatedResult:
         """Query items using a key condition expression."""
 
+    def query_all(self, params: QueryParams, *, max_pages: int = 100) -> list[dict[str, Any]]:
+        """Query every matching item, following the pagination cursor to exhaustion.
+
+        :meth:`query` returns ONE page. DynamoDB caps a response at 1 MB
+        regardless of how many items match, so a caller that reads
+        ``result.items`` and stops silently truncates its result set with no
+        error — the failure mode is invisible at the call site. That is merely a
+        short list for a listing endpoint, but for authorization data it means
+        roles or data restrictions disappear, so every authorization-critical
+        read must use this method rather than ``query``.
+
+        ``params.limit`` is left untouched (it bounds each page, not the total).
+        Any ``exclusive_start_key`` on ``params`` is honoured as the starting
+        cursor.
+
+        Args:
+            params: Query parameters; the cursor is advanced internally.
+            max_pages: Safety bound on pages read. Reaching it raises rather than
+                returning a partial set — a silent truncation here is exactly the
+                bug this method exists to prevent, and a partition needing more
+                than this indicates a data-model problem worth surfacing.
+
+        Returns:
+            Every matching item across all pages.
+
+        Raises:
+            RuntimeError: If ``max_pages`` is exhausted while a cursor remains.
+        """
+        from dataclasses import replace
+
+        items: list[dict[str, Any]] = []
+        page_params = params
+        for _ in range(max_pages):
+            page = self.query(page_params)
+            items.extend(page.items)
+            if not page.last_evaluated_key:
+                return items
+            page_params = replace(page_params, exclusive_start_key=page.last_evaluated_key)
+        raise RuntimeError(
+            f"query_all exceeded {max_pages} pages without exhausting the cursor "
+            f"(index={params.index_name!r}); refusing to return a partial result set"
+        )
+
     @abstractmethod
     def atomic_increment(
         self,

--- a/libs/common/tests/unit/test_dao.py
+++ b/libs/common/tests/unit/test_dao.py
@@ -239,6 +239,108 @@ class TestDynamoDBDAOQuery:
         assert call_args["Limit"] == 10
 
 
+class TestDynamoDBDAOQueryAll:
+    """query_all must follow LastEvaluatedKey to exhaustion.
+
+    DynamoDB caps a query response at 1 MB regardless of how many items match, so
+    a caller reading only ``result.items`` silently truncates. For authorization
+    reads that means roles / data restrictions disappear with no error.
+    """
+
+    def test_follows_pagination_cursor_across_pages(self, mock_table):
+        table, _ = mock_table
+        table.query.side_effect = [
+            {"Items": [{"PK": "a"}], "LastEvaluatedKey": {"PK": "a"}},
+            {"Items": [{"PK": "b"}], "LastEvaluatedKey": {"PK": "b"}},
+            {"Items": [{"PK": "c"}]},
+        ]
+
+        dao = DynamoDBDAO("test-table", region="us-east-1")
+        items = dao.query_all(QueryParams(key_condition="PK = :pk", expression_values={":pk": "x"}))
+
+        assert [i["PK"] for i in items] == ["a", "b", "c"]
+        assert table.query.call_count == 3
+
+    def test_passes_cursor_as_exclusive_start_key(self, mock_table):
+        table, _ = mock_table
+        table.query.side_effect = [
+            {"Items": [{"PK": "a"}], "LastEvaluatedKey": {"PK": "a", "SK": "s"}},
+            {"Items": [{"PK": "b"}]},
+        ]
+
+        dao = DynamoDBDAO("test-table", region="us-east-1")
+        dao.query_all(QueryParams(key_condition="PK = :pk", expression_values={":pk": "x"}))
+
+        assert table.query.call_args_list[1].kwargs["ExclusiveStartKey"] == {"PK": "a", "SK": "s"}
+
+    def test_single_page_makes_one_call(self, mock_table):
+        table, _ = mock_table
+        table.query.return_value = {"Items": [{"PK": "a"}]}
+
+        dao = DynamoDBDAO("test-table", region="us-east-1")
+        items = dao.query_all(QueryParams(key_condition="PK = :pk", expression_values={":pk": "x"}))
+
+        assert len(items) == 1
+        assert table.query.call_count == 1
+
+    def test_empty_result(self, mock_table):
+        table, _ = mock_table
+        table.query.return_value = {"Items": []}
+
+        dao = DynamoDBDAO("test-table", region="us-east-1")
+        assert dao.query_all(QueryParams(key_condition="PK = :pk", expression_values={":pk": "x"})) == []
+
+    def test_preserves_index_and_expression_names_on_every_page(self, mock_table):
+        table, _ = mock_table
+        table.query.side_effect = [
+            {"Items": [{"PK": "a"}], "LastEvaluatedKey": {"PK": "a"}},
+            {"Items": [{"PK": "b"}]},
+        ]
+
+        dao = DynamoDBDAO("test-table", region="us-east-1")
+        dao.query_all(
+            QueryParams(
+                key_condition="#pk = :pk",
+                expression_values={":pk": "x"},
+                expression_names={"#pk": "principalKey"},
+                index_name="PrincipalIndex",
+            )
+        )
+
+        for call in table.query.call_args_list:
+            assert call.kwargs["IndexName"] == "PrincipalIndex"
+            assert call.kwargs["ExpressionAttributeNames"] == {"#pk": "principalKey"}
+
+    def test_honours_a_caller_supplied_start_cursor(self, mock_table):
+        table, _ = mock_table
+        table.query.return_value = {"Items": [{"PK": "b"}]}
+
+        dao = DynamoDBDAO("test-table", region="us-east-1")
+        dao.query_all(
+            QueryParams(
+                key_condition="PK = :pk",
+                expression_values={":pk": "x"},
+                exclusive_start_key={"PK": "a"},
+            )
+        )
+
+        assert table.query.call_args.kwargs["ExclusiveStartKey"] == {"PK": "a"}
+
+    def test_raises_rather_than_returning_a_partial_set(self, mock_table):
+        """Hitting the page bound must fail loudly — silent truncation is the bug."""
+        table, _ = mock_table
+        table.query.return_value = {"Items": [{"PK": "a"}], "LastEvaluatedKey": {"PK": "a"}}
+
+        dao = DynamoDBDAO("test-table", region="us-east-1")
+        with pytest.raises(RuntimeError, match="without exhausting the cursor"):
+            dao.query_all(
+                QueryParams(key_condition="PK = :pk", expression_values={":pk": "x"}),
+                max_pages=3,
+            )
+
+        assert table.query.call_count == 3
+
+
 class TestDynamoDBDAOBatchGet:
     def test_batch_get(self, mock_table):
         _, mock_resource = mock_table

--- a/packages/context-manager/src/coa_serve/clients/bedrock.py
+++ b/packages/context-manager/src/coa_serve/clients/bedrock.py
@@ -272,11 +272,20 @@ class BedrockLLMClient:
         queue: asyncio.Queue[str | None | Exception | tuple] = asyncio.Queue()
         loop = asyncio.get_running_loop()
 
-        # Published by the worker as soon as the EventStream exists, so the
-        # event-loop side can close it. Closing the stream is what actually
-        # unblocks the worker's synchronous `for event in ...` — there is no other
-        # cancellation path into a thread-pool thread.
+        # Shared state between the event loop and the worker thread.
+        #
+        # ``stream`` is published by the worker as soon as the EventStream exists so
+        # this side can close it — closing is what unblocks the worker's synchronous
+        # `for event in ...`, since a thread-pool thread has no cancellation point.
+        #
+        # ``abandoned`` covers the window BEFORE that: the ConverseStream API call
+        # itself takes time, and a client that disconnects during it would find
+        # nothing to close, leaving the worker to drain the whole response (holding
+        # an executor slot and billing tokens) for a caller that is already gone.
+        # The worker checks the flag right after the call returns, and again on each
+        # event, so it exits at the first opportunity either way.
         stream_holder: dict[str, Any] = {}
+        abandoned = threading.Event()
 
         def _run_stream() -> None:
             """Run in thread — iterate EventStream, push text chunks to queue."""
@@ -286,7 +295,15 @@ class BedrockLLMClient:
                 client = self._get_client()
                 response = self._call_with_temperature_fallback(client.converse_stream, kwargs)
                 stream_holder["stream"] = response["stream"]
+                if abandoned.is_set():
+                    # Disconnected while the API call was in flight — nothing was
+                    # closeable at that point, so honour the request here.
+                    _close_stream_quietly(response["stream"])
+                    return
                 for event in response["stream"]:
+                    if abandoned.is_set():
+                        _close_stream_quietly(response["stream"])
+                        return
                     if "contentBlockDelta" in event:
                         text = event["contentBlockDelta"].get("delta", {}).get("text", "")
                         if text:
@@ -345,10 +362,14 @@ class BedrockLLMClient:
             # at the `yield`, and suspending on an await inside the resulting
             # `finally` makes CPython raise "async generator ignored GeneratorExit".
             #
-            # Instead: close the stream from this side to unblock the thread, then
-            # detach the worker with a done-callback that surfaces any error. The
-            # generator finalizes synchronously, and the worker cannot keep consuming
-            # the Bedrock stream (and billing tokens) after the client is gone.
+            # Instead: signal the worker to stop, close the stream from this side to
+            # unblock it, then detach it with a done-callback that surfaces any
+            # error. The generator finalizes synchronously, and the worker cannot
+            # keep consuming the Bedrock stream (and billing tokens) after the
+            # client is gone. Setting the flag as well as closing covers the window
+            # where the API call has not returned yet, so there is no stream to
+            # close — see the comment on ``abandoned``.
+            abandoned.set()
             _close_stream_quietly(stream_holder.get("stream"))
             task.add_done_callback(_log_detached_worker_result)
 

--- a/packages/context-manager/src/coa_serve/clients/bedrock.py
+++ b/packages/context-manager/src/coa_serve/clients/bedrock.py
@@ -61,6 +61,40 @@ def _assessment_has_block(assessment: dict) -> bool:
         return False
 
 
+def _close_stream_quietly(stream: Any) -> None:
+    """Close a boto3 EventStream, ignoring absence and close errors.
+
+    Closing the underlying HTTP response is the only way to unblock a worker thread
+    parked in ``for event in stream``: a thread-pool thread has no cancellation
+    point. Best-effort by design — this runs during generator finalization, where
+    raising would mask the original outcome.
+    """
+    if stream is None:
+        return
+    close = getattr(stream, "close", None)
+    if close is None:
+        return
+    try:
+        close()
+    except Exception as exc:  # noqa: BLE001 - finalization must not raise
+        logger.debug("bedrock_stream_close_failed", error=type(exc).__name__, error_msg=str(exc))
+
+
+def _log_detached_worker_result(task: Any) -> None:
+    """Surface a detached stream worker's failure instead of discarding it.
+
+    Attached as a done-callback once the generator stops awaiting the worker, so an
+    exception raised after detachment is still visible rather than swallowed by the
+    unretrieved-result warning.
+    """
+    try:
+        task.result()
+    except asyncio.CancelledError:  # pragma: no cover - normal on shutdown
+        pass
+    except Exception as exc:  # noqa: BLE001 - diagnostics only
+        logger.debug("bedrock_stream_worker_after_detach", error=type(exc).__name__, error_msg=str(exc))
+
+
 class BedrockLLMClient:
     """Bedrock Converse API + embeddings client (Cohere Embed v4 by default)."""
 
@@ -180,7 +214,10 @@ class BedrockLLMClient:
         if not text_blocks:
             raise ValueError(f"No text content in Bedrock response: stopReason={stop_reason}")
 
-        text = text_blocks[0]
+        # Join ALL text blocks. The Converse API may split a response across several
+        # content blocks; taking only the first silently truncated the generation
+        # (and for NL→SQL / NL→SPARQL that means a query cut off mid-statement).
+        text = "".join(text_blocks)
         blocked = False
 
         # Parse guardrail trace to distinguish BLOCK from ANONYMIZE.
@@ -235,6 +272,12 @@ class BedrockLLMClient:
         queue: asyncio.Queue[str | None | Exception | tuple] = asyncio.Queue()
         loop = asyncio.get_running_loop()
 
+        # Published by the worker as soon as the EventStream exists, so the
+        # event-loop side can close it. Closing the stream is what actually
+        # unblocks the worker's synchronous `for event in ...` — there is no other
+        # cancellation path into a thread-pool thread.
+        stream_holder: dict[str, Any] = {}
+
         def _run_stream() -> None:
             """Run in thread — iterate EventStream, push text chunks to queue."""
             guardrail_triggered = False
@@ -242,6 +285,7 @@ class BedrockLLMClient:
             try:
                 client = self._get_client()
                 response = self._call_with_temperature_fallback(client.converse_stream, kwargs)
+                stream_holder["stream"] = response["stream"]
                 for event in response["stream"]:
                     if "contentBlockDelta" in event:
                         text = event["contentBlockDelta"].get("delta", {}).get("text", "")
@@ -289,7 +333,24 @@ class BedrockLLMClient:
         except TimeoutError:
             pending_exception = TimeoutError("Bedrock stream timed out waiting for next token")
         finally:
-            await task
+            # Do NOT await the worker here.
+            #
+            # The worker iterates boto3's SYNCHRONOUS EventStream in a thread-pool
+            # thread and has no cancellation point, so awaiting it blocked for up to
+            # BEDROCK_READ_TIMEOUT (120s) more — which defeated the 300s idle-timeout
+            # guard above: it fired, then this line waited again.
+            #
+            # Worse, on early generator close (the SSE consumer in main.py cancelling
+            # resolve_task when the client disconnects) `GeneratorExit` is thrown in
+            # at the `yield`, and suspending on an await inside the resulting
+            # `finally` makes CPython raise "async generator ignored GeneratorExit".
+            #
+            # Instead: close the stream from this side to unblock the thread, then
+            # detach the worker with a done-callback that surfaces any error. The
+            # generator finalizes synchronously, and the worker cannot keep consuming
+            # the Bedrock stream (and billing tokens) after the client is gone.
+            _close_stream_quietly(stream_holder.get("stream"))
+            task.add_done_callback(_log_detached_worker_result)
 
         if pending_exception:
             raise pending_exception

--- a/packages/context-manager/src/coa_serve/role_resolver.py
+++ b/packages/context-manager/src/coa_serve/role_resolver.py
@@ -125,10 +125,20 @@ def _merge_data_restrictions(
       If ANY grant has no allowlist, the user has unrestricted table access.
     - columnDenylist: INTERSECTION across all matching grants (most permissive).
       A column is denied only if ALL matching grants deny it.
+
+    Scoped to grants on THIS namespace. A ``GLOBAL``-scoped grant (the shape
+    platform-admin / platform-viewer are written with) must NOT participate:
+    platform grants carry no tableAllowlist/columnDenylist fields, so the
+    "any grant without a restriction means unrestricted" rule above would fire
+    on them and erase the namespace grant's restrictions entirely — a user who
+    holds both a restricted namespace role and a platform role would get
+    unrestricted data access, and the SQL firewall would log the query as
+    ``restricted=False`` (no trace of a bypass). Platform privileges still flow
+    through ``result.global_roles``, which is resolved separately in
+    ``resolve_profile`` and drives the Cedar action-level layer; only the
+    data-level merge is namespace-scoped.
     """
-    namespace_grants = [
-        item for item in items if item.get("resourceId") == namespace or item.get("resourceId") == "GLOBAL"
-    ]
+    namespace_grants = [item for item in items if item.get("resourceId") == namespace]
 
     if not namespace_grants:
         return
@@ -160,9 +170,6 @@ def _merge_data_restrictions(
 
     if not has_unrestricted_metrics and merged_metrics:
         result.allowed_metrics = sorted(merged_metrics)
-
-    if not has_unrestricted_grant and merged_tables:
-        result.table_allowlist = sorted(merged_tables)
 
     # Column denylist: intersection (only deny if ALL grants deny it)
     denylist_sets: list[dict[str, set[str]]] = []

--- a/packages/context-manager/src/coa_serve/role_resolver.py
+++ b/packages/context-manager/src/coa_serve/role_resolver.py
@@ -70,6 +70,12 @@ def resolve_profile(
 
     If no namespace is provided, only roles are resolved (no table/column merge).
     If RRM_TABLE_NAME is not configured, returns a minimal profile with just userId/groups.
+
+    Raises:
+        Exception: Propagates a grant-lookup failure. Resolution must not fall
+            back to a partial read — restrictions derived from a subset of the
+            grants are more permissive than the truth, so a transient DynamoDB
+            error would widen data access.
     """
     result = ResolvedProfile(user_id=user_id, groups=groups)
 
@@ -81,21 +87,35 @@ def resolve_profile(
     principal_keys = [f"User::{sanitize_principal_key(user_id)}"]
     principal_keys.extend(f"Group::{sanitize_principal_key(g)}" for g in groups)
 
-    # Collect all grant items for this principal
+    # Collect all grant items for this principal.
+    #
+    # query_all, not query: one query returns a single 1 MB page, and the grants
+    # on later pages carry tableAllowlist / columnDenylist. Dropping a restricted
+    # grant while an unrestricted one survives makes _merge_data_restrictions see
+    # no restrictions at all, so the SQL firewall stops enforcing them — a PII
+    # denylist silently disabled by a pagination boundary.
+    #
+    # A failure here must NOT degrade to a partial read for the same reason: the
+    # restrictions computed from a subset are more permissive than the truth. Fail
+    # the resolution instead and let the caller reject the request, matching the
+    # control-plane authorizer's fail-closed posture (it re-raises in the
+    # equivalent spot).
     all_items: list[dict[str, Any]] = []
     for pk in principal_keys:
         try:
-            query_result = dao.query(
-                QueryParams(
-                    key_condition="#pk = :pk",
-                    expression_values={":pk": pk},
-                    expression_names={"#pk": "principalKey"},
-                    index_name="PrincipalIndex",
+            all_items.extend(
+                dao.query_all(
+                    QueryParams(
+                        key_condition="#pk = :pk",
+                        expression_values={":pk": pk},
+                        expression_names={"#pk": "principalKey"},
+                        index_name="PrincipalIndex",
+                    )
                 )
             )
-            all_items.extend(query_result.items)
         except Exception:
             logger.exception("role_resolve_query_failed", principal_key=pk)
+            raise
 
     # Resolve roles from all items
     for item in all_items:

--- a/packages/context-manager/src/coa_serve/tier2/ontop/strategy.py
+++ b/packages/context-manager/src/coa_serve/tier2/ontop/strategy.py
@@ -29,6 +29,9 @@ logger = structlog.get_logger(__name__)
 
 _TIER2_TOOL_USED = TOOL_FOR_STEP
 
+# k-NN depth for the TBox-context retrieval feeding NL→SPARQL.
+_VECTOR_TOP_K = 10
+
 _RETRYABLE_VKG_PATTERNS = (
     "cannot translate",
     "unsupported sparql",
@@ -305,10 +308,54 @@ class OntopStrategy:
             return None
         try:
             index_name = ontology_vector_index_name(self._oss_ontology_index, namespace)
-            raw_hits = await self._vector_client.search(embedding, namespace=namespace, top_k=10, index=index_name)
-            logger.debug(
+
+            # Restrict the CLASS retrieval to R2RML-mapped classes, matching the
+            # gate NL→SQL applies (nl_to_sql/sql_generator.py). Unmapped classes —
+            # document-induced or from a loaded foundational ontology — have no
+            # table behind them, so authoring SPARQL against them produces a query
+            # VKG cannot compile: nothing comes back, in exactly the mixed
+            # DATABASE + DOCUMENTS namespace the ``is_mapped`` design exists to
+            # protect (see external-docs "Mapped classes and Tier-2
+            # answerability"). Without the gate a document-heavy query filled the
+            # top-k with unmapped classes; the provenance skip evaluator only
+            # bails when ALL top-k hits are unmapped, so the partial mix fell
+            # through untouched.
+            #
+            # Legacy bridge, same as NL→SQL: namespaces ingested before
+            # ``data_source_id`` was written carry zero mapped records, and gating
+            # them would hide every class. One cheap count decides whether the
+            # gate applies at all.
+            mapped_count = await self._vector_client.count_documents(
+                index=index_name, entity_type="class", require_mapped=True
+            )
+            use_mapped_gate = mapped_count > 0
+
+            class_hits = await self._vector_client.search(
+                embedding,
+                namespace=namespace,
+                top_k=_VECTOR_TOP_K,
+                index=index_name,
+                entity_type="class",
+                require_mapped=use_mapped_gate,
+            )
+            # Properties and metrics are fetched unfiltered: only classes carry the
+            # data_source_id stamp the mapped gate reads, and metrics are resolved
+            # through Tier-1 rather than the VKG mapping. Classes are dropped from
+            # this pass — they are already covered by the gated search above, and
+            # keeping them would both duplicate hits and reintroduce the unmapped
+            # classes the gate just excluded.
+            other_hits = await self._vector_client.search(
+                embedding, namespace=namespace, top_k=_VECTOR_TOP_K, index=index_name
+            )
+            raw_hits = [*class_hits, *(h for h in other_hits if h.metadata.get("entity_type") != "class")]
+
+            logger.info(
                 "tier2_aoss_raw_hits",
+                namespace=namespace,
                 count=len(raw_hits),
+                mapped_gate=use_mapped_gate,
+                mapped_count=mapped_count,
+                class_hits=len(class_hits),
                 sample_types=[h.metadata.get("entity_type", "MISSING") for h in raw_hits[:5]],
             )
             hits = []

--- a/packages/context-manager/tests/unit/test_bedrock.py
+++ b/packages/context-manager/tests/unit/test_bedrock.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 from unittest.mock import MagicMock
 
 import pytest
@@ -586,6 +588,72 @@ class TestConverseStreamCleanup:
         client = self._client_over(iter(events))
 
         assert [t async for t in client.converse_stream("q")] == ["a", "b"]
+
+    async def test_abandon_during_the_api_call_still_releases_the_worker(self):
+        """The window before the EventStream exists.
+
+        `converse_stream` (the boto3 call) takes time; a client disconnecting during
+        it finds nothing to close, so the worker would drain the entire response —
+        holding an executor slot and billing tokens for a caller already gone. The
+        `abandoned` flag covers that window.
+        """
+        import threading
+        import time
+
+        closed = threading.Event()
+        drained_fully = threading.Event()
+
+        class _Stream:
+            def __iter__(self):
+                for _ in range(40):
+                    if closed.is_set():
+                        raise RuntimeError("closed")
+                    time.sleep(0.02)
+                drained_fully.set()
+                yield {"contentBlockDelta": {"delta": {"text": "late"}}}
+
+            def close(self):
+                closed.set()
+
+        def _slow_api(**_kwargs):
+            time.sleep(0.3)  # API in flight — nothing closeable yet
+            return {"stream": _Stream()}
+
+        from coa_serve.clients.bedrock import BedrockLLMClient
+
+        mock_client = MagicMock()
+        mock_client.converse_stream = _slow_api
+        client = BedrockLLMClient(model_id="test-model", region="us-east-1")
+        client._client = mock_client
+
+        agen = client.converse_stream("q")
+        pending = asyncio.ensure_future(agen.__anext__())
+        await asyncio.sleep(0.05)  # disconnect BEFORE the API returns
+        pending.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await pending
+        await agen.aclose()
+
+        # The worker sees the flag right after the API call returns.
+        for _ in range(50):
+            if closed.is_set():
+                break
+            await asyncio.sleep(0.05)
+
+        assert closed.is_set(), "worker kept the stream open after the caller left"
+        assert not drained_fully.is_set(), "worker drained the whole response for a gone caller"
+
+    async def test_normal_completion_is_not_treated_as_abandoned(self):
+        """The flag must not fire on the healthy path and truncate the stream."""
+        events = [
+            {"contentBlockDelta": {"delta": {"text": "a"}}},
+            {"contentBlockDelta": {"delta": {"text": "b"}}},
+            {"contentBlockDelta": {"delta": {"text": "c"}}},
+            {"messageStop": {"stopReason": "end_turn"}},
+        ]
+        client = self._client_over(iter(events))
+
+        assert [t async for t in client.converse_stream("q")] == ["a", "b", "c"]
 
     async def test_stream_without_close_method_is_tolerated(self):
         """A plain iterator has no close(); finalization must still not raise."""

--- a/packages/context-manager/tests/unit/test_bedrock.py
+++ b/packages/context-manager/tests/unit/test_bedrock.py
@@ -459,6 +459,143 @@ class TestBedrockConverseStream:
 
 
 @pytest.mark.unit
+class TestConverseMultipleTextBlocks:
+    """The Converse API may split a response across several content blocks."""
+
+    async def test_all_text_blocks_are_joined(self):
+        from coa_serve.clients.bedrock import BedrockLLMClient
+
+        mock_client = MagicMock()
+        mock_client.converse.return_value = {
+            "output": {
+                "message": {
+                    "content": [
+                        {"text": "SELECT ?claim WHERE {"},
+                        {"text": " ?claim a :Claim }"},
+                    ]
+                }
+            }
+        }
+        client = BedrockLLMClient(model_id="test-model", region="us-east-1")
+        client._client = mock_client
+
+        result = await client.converse("q")
+
+        assert result.text == "SELECT ?claim WHERE { ?claim a :Claim }", (
+            "blocks after the first were dropped, truncating the generation"
+        )
+
+    async def test_non_text_blocks_are_still_skipped(self):
+        from coa_serve.clients.bedrock import BedrockLLMClient
+
+        mock_client = MagicMock()
+        mock_client.converse.return_value = {
+            "output": {
+                "message": {
+                    "content": [
+                        {"text": "a"},
+                        {"toolUse": {"name": "x"}},
+                        {"text": "b"},
+                    ]
+                }
+            }
+        }
+        client = BedrockLLMClient(model_id="test-model", region="us-east-1")
+        client._client = mock_client
+
+        assert (await client.converse("q")).text == "ab"
+
+
+@pytest.mark.unit
+class TestConverseStreamCleanup:
+    """Generator finalization must not block on the uncancellable worker thread.
+
+    The worker iterates boto3's synchronous EventStream in a thread-pool thread, so
+    there is no cancellation point: `await task` in `finally` waited out
+    BEDROCK_READ_TIMEOUT, defeating the idle-timeout guard, and on early close it
+    suspended inside GeneratorExit handling — which CPython rejects for async
+    generators ("async generator ignored GeneratorExit").
+    """
+
+    class _BlockingStream:
+        """Emits one chunk, then blocks like boto3's EventStream until closed."""
+
+        def __init__(self, ticks: int = 200, tick_s: float = 0.05):
+            self.closed = False
+            self._ticks = ticks
+            self._tick_s = tick_s
+
+        def __iter__(self):
+            import time
+
+            yield {"contentBlockDelta": {"delta": {"text": "hello"}}}
+            for _ in range(self._ticks):
+                if self.closed:
+                    raise RuntimeError("stream closed")
+                time.sleep(self._tick_s)
+
+        def close(self):
+            self.closed = True
+
+    def _client_over(self, stream):
+        from coa_serve.clients.bedrock import BedrockLLMClient
+
+        mock_client = MagicMock()
+        mock_client.converse_stream.return_value = {"stream": stream}
+        client = BedrockLLMClient(model_id="test-model", region="us-east-1")
+        client._client = mock_client
+        return client
+
+    async def test_early_close_returns_promptly(self):
+        import time
+
+        stream = self._BlockingStream()
+        agen = self._client_over(stream).converse_stream("q")
+
+        assert await agen.__anext__() == "hello"
+        started = time.monotonic()
+        await agen.aclose()
+        elapsed = time.monotonic() - started
+
+        assert elapsed < 2.0, f"aclose() blocked for {elapsed:.1f}s waiting on the worker thread"
+
+    async def test_early_close_closes_the_upstream_stream(self):
+        """Otherwise the worker keeps consuming Bedrock (and billing) after disconnect."""
+        stream = self._BlockingStream()
+        agen = self._client_over(stream).converse_stream("q")
+
+        await agen.__anext__()
+        await agen.aclose()
+
+        assert stream.closed
+
+    async def test_early_close_does_not_raise(self):
+        stream = self._BlockingStream()
+        agen = self._client_over(stream).converse_stream("q")
+
+        await agen.__anext__()
+        await agen.aclose()  # must not raise "async generator ignored GeneratorExit"
+
+    async def test_normal_completion_still_yields_every_token(self):
+        """The detached-worker change must not truncate a healthy stream."""
+        events = [
+            {"contentBlockDelta": {"delta": {"text": "a"}}},
+            {"contentBlockDelta": {"delta": {"text": "b"}}},
+            {"messageStop": {"stopReason": "end_turn"}},
+        ]
+        client = self._client_over(iter(events))
+
+        assert [t async for t in client.converse_stream("q")] == ["a", "b"]
+
+    async def test_stream_without_close_method_is_tolerated(self):
+        """A plain iterator has no close(); finalization must still not raise."""
+        agen = self._client_over(iter([{"contentBlockDelta": {"delta": {"text": "x"}}}])).converse_stream("q")
+
+        assert await agen.__anext__() == "x"
+        await agen.aclose()
+
+
+@pytest.mark.unit
 class TestModelIdValidation:
     def test_validate_rejects_empty(self):
         from coa_serve.model_validation import validate_model_id

--- a/packages/context-manager/tests/unit/test_ontop_strategy.py
+++ b/packages/context-manager/tests/unit/test_ontop_strategy.py
@@ -347,14 +347,24 @@ class TestOntopStrategyVectorHits:
             oss_ontology_index="test-index",
         )
 
-        # Vector search returns mixed entity types
-        vector_client.search.return_value = [
-            BaseVectorHit(id="1", text="ClassA", score=0.9, metadata={"entity_type": "class", "entity_uri": "uri:A"}),
-            BaseVectorHit(
-                id="2", text="PropB", score=0.85, metadata={"entity_type": "property", "entity_uri": "uri:B"}
-            ),
-            BaseVectorHit(id="3", text="MetricC", score=0.8, metadata={"entity_type": "metric", "entity_uri": "uri:C"}),
-            BaseVectorHit(id="4", text="Unknown", score=0.7, metadata={"entity_type": "unknown"}),
+        # Classes are retrieved in their own mapped-gated search; properties and
+        # metrics come from the unfiltered one (see _fetch_vector_hits).
+        class_hit = BaseVectorHit(
+            id="1", text="ClassA", score=0.9, metadata={"entity_type": "class", "entity_uri": "uri:A"}
+        )
+        vector_client.count_documents.return_value = 5  # namespace has mapped classes
+        vector_client.search.side_effect = [
+            [class_hit],
+            [
+                class_hit,  # re-returned by the unfiltered pass; must not be counted twice
+                BaseVectorHit(
+                    id="2", text="PropB", score=0.85, metadata={"entity_type": "property", "entity_uri": "uri:B"}
+                ),
+                BaseVectorHit(
+                    id="3", text="MetricC", score=0.8, metadata={"entity_type": "metric", "entity_uri": "uri:C"}
+                ),
+                BaseVectorHit(id="4", text="Unknown", score=0.7, metadata={"entity_type": "unknown"}),
+            ],
         ]
         nl_to_sparql.translate.return_value = _make_sparql_result(valid=False)
 
@@ -370,6 +380,107 @@ class TestOntopStrategyVectorHits:
         assert hits[0].type == "ontology_class"
         assert hits[1].type == "ontology_property"
         assert hits[2].type == "metric"
+
+    # ── mapped-class gate (parity with nl_to_sql/sql_generator.py) ───────────
+    # Unmapped classes (document-induced, or from a loaded foundational ontology)
+    # have no table behind them, so SPARQL authored against them cannot compile in
+    # VKG and the query silently returns nothing. NL→SQL gated its class retrieval
+    # on `require_mapped`; the Ontop path did not, so a document-heavy query in a
+    # mixed namespace filled its top-k with unmapped classes. The provenance skip
+    # evaluator only bails when ALL top-k hits are unmapped, so the partial mix
+    # fell straight through.
+
+    def _strategy(self, nl_to_sparql, vkg_translator, vector_client):
+        return OntopStrategy(
+            nl_to_sparql=nl_to_sparql,
+            vkg_translator=vkg_translator,
+            vector_client=vector_client,
+            oss_ontology_index="test-index",
+        )
+
+    @pytest.mark.asyncio
+    async def test_class_search_is_gated_on_mapped_when_mapped_classes_exist(
+        self, nl_to_sparql, vkg_translator, vector_client
+    ):
+        vector_client.count_documents.return_value = 3
+        vector_client.search.return_value = []
+        nl_to_sparql.translate.return_value = _make_sparql_result(valid=False)
+
+        await self._strategy(nl_to_sparql, vkg_translator, vector_client).resolve(
+            "query", "ns1", _make_context(embedding=[0.1] * 10)
+        )
+
+        class_call = next(c for c in vector_client.search.call_args_list if c.kwargs.get("entity_type") == "class")
+        assert class_call.kwargs["require_mapped"] is True
+
+    @pytest.mark.asyncio
+    async def test_gate_is_dropped_for_a_namespace_with_no_mapped_classes(
+        self, nl_to_sparql, vkg_translator, vector_client
+    ):
+        """Legacy bridge: gating a namespace ingested before data_source_id existed
+        would hide every class and take Tier-2 dark."""
+        vector_client.count_documents.return_value = 0
+        vector_client.search.return_value = []
+        nl_to_sparql.translate.return_value = _make_sparql_result(valid=False)
+
+        await self._strategy(nl_to_sparql, vkg_translator, vector_client).resolve(
+            "query", "ns1", _make_context(embedding=[0.1] * 10)
+        )
+
+        class_call = next(c for c in vector_client.search.call_args_list if c.kwargs.get("entity_type") == "class")
+        assert class_call.kwargs["require_mapped"] is False
+
+    @pytest.mark.asyncio
+    async def test_unmapped_classes_from_the_unfiltered_pass_are_excluded(
+        self, nl_to_sparql, vkg_translator, vector_client
+    ):
+        """The second (unfiltered) search exists for properties/metrics only — its
+        classes must not slip past the gate."""
+        vector_client.count_documents.return_value = 2
+        vector_client.search.side_effect = [
+            [
+                BaseVectorHit(
+                    id="1", text="MappedClass", score=0.9, metadata={"entity_type": "class", "entity_uri": "uri:mapped"}
+                )
+            ],
+            [
+                BaseVectorHit(
+                    id="9",
+                    text="UnmappedDocClass",
+                    score=0.95,
+                    metadata={"entity_type": "class", "entity_uri": "uri:unmapped"},
+                ),
+                BaseVectorHit(
+                    id="2", text="PropB", score=0.8, metadata={"entity_type": "property", "entity_uri": "uri:B"}
+                ),
+            ],
+        ]
+        nl_to_sparql.translate.return_value = _make_sparql_result(valid=False)
+
+        await self._strategy(nl_to_sparql, vkg_translator, vector_client).resolve(
+            "query", "ns1", _make_context(embedding=[0.1] * 10)
+        )
+
+        hits = nl_to_sparql.translate.call_args[1]["vector_hits"]
+        uris = {h.uri for h in hits}
+        assert "uri:mapped" in uris
+        assert "uri:unmapped" not in uris, "an unmapped class reached the NL→SPARQL context"
+
+    @pytest.mark.asyncio
+    async def test_properties_and_metrics_are_not_mapped_gated(self, nl_to_sparql, vkg_translator, vector_client):
+        """Only classes carry the data_source_id stamp the gate reads."""
+        vector_client.count_documents.return_value = 4
+        vector_client.search.return_value = []
+        nl_to_sparql.translate.return_value = _make_sparql_result(valid=False)
+
+        await self._strategy(nl_to_sparql, vkg_translator, vector_client).resolve(
+            "query", "ns1", _make_context(embedding=[0.1] * 10)
+        )
+
+        unfiltered = [c for c in vector_client.search.call_args_list if "entity_type" not in c.kwargs]
+        assert unfiltered, "expected an unfiltered search for properties/metrics"
+        for call in unfiltered:
+            assert not call.kwargs.get("require_mapped")
 
     @pytest.mark.asyncio
     async def test_vector_search_exception_returns_none_gracefully(self, nl_to_sparql, vkg_translator, vector_client):

--- a/packages/context-manager/tests/unit/test_role_resolver.py
+++ b/packages/context-manager/tests/unit/test_role_resolver.py
@@ -27,18 +27,22 @@ def _result(items):
 
 
 def _mock_dao(items_by_pk):
-    """Return a DynamoDBDAO factory whose query() dispatches on principalKey.
+    """Return a DynamoDBDAO factory whose query dispatches on principalKey.
 
     ``items_by_pk`` maps the ``:pk`` expression value to the list of grant items
     returned for that principal.
+
+    Both ``query`` and ``query_all`` are stubbed: the resolver uses ``query_all``
+    (a single page would silently drop grants past 1 MB), and ``query_all``
+    returns a plain list rather than a ``PaginatedResult``.
     """
     dao = MagicMock()
 
-    def _query(params):
-        pk = params.expression_values[":pk"]
-        return _result(items_by_pk.get(pk, []))
+    def _items_for(params):
+        return items_by_pk.get(params.expression_values[":pk"], [])
 
-    dao.query.side_effect = _query
+    dao.query.side_effect = lambda params: _result(_items_for(params))
+    dao.query_all.side_effect = _items_for
     return dao
 
 
@@ -78,17 +82,25 @@ class TestResolveProfileRoles:
         assert "platform-viewer" in resolved.global_roles
         assert {"role": "namespace-maintainer", "resourceUID": _NS} in resolved.resource_roles
 
-    def test_query_exception_is_swallowed(self):
+    def test_query_exception_propagates(self):
+        """A grant-lookup failure must NOT degrade to a partial read.
+
+        Previously the exception was swallowed and resolution continued with
+        whatever had been collected. That is unsafe for this specific data:
+        restrictions computed from a subset of the grants are more PERMISSIVE
+        than the truth (see `_merge_data_restrictions` — a missing restricted
+        grant leaves `tableAllowlist`/`columnDenylist` unset, which the SQL
+        firewall reads as unrestricted). So a transient DynamoDB error widened
+        data access. Fail closed instead, matching the control-plane authorizer.
+        """
         dao = MagicMock()
-        dao.query.side_effect = RuntimeError("ddb down")
+        dao.query_all.side_effect = RuntimeError("ddb down")
         with (
             patch.object(role_resolver, "_RRM_TABLE", "rrm"),
             patch.object(role_resolver, "DynamoDBDAO", return_value=dao),
+            pytest.raises(RuntimeError, match="ddb down"),
         ):
-            resolved = resolve_profile("bob@x.com", [], namespace=_NS)
-        # No roles resolved, but no exception propagated (fail-closed posture).
-        assert resolved.global_roles == []
-        assert resolved.resource_roles == []
+            resolve_profile("bob@x.com", [], namespace=_NS)
 
     def test_no_namespace_skips_data_restriction_merge(self):
         items = {"User::alice@x.com": [{"role": "platform-admin", "resourceId": "GLOBAL"}]}
@@ -116,9 +128,25 @@ class TestResolveProfileRoles:
         ):
             resolve_profile("foo+123@x.com", ["group/eng"], namespace=_NS)
 
-        queried_pks = [call.args[0].expression_values[":pk"] for call in dao.query.call_args_list]
+        queried_pks = [call.args[0].expression_values[":pk"] for call in dao.query_all.call_args_list]
         assert "User::foo%2B123@x.com" in queried_pks
         assert "Group::group%2Feng" in queried_pks
+
+    def test_reads_every_page_of_grants(self):
+        """Grants must be read with query_all, not a single 1 MB query page.
+
+        A one-page read drops grants past the page boundary; when the dropped one
+        carries the restrictions, the SQL firewall stops enforcing them.
+        """
+        dao = _mock_dao({"User::u": [{"role": "data-analyst", "resourceId": _NS}]})
+        with (
+            patch.object(role_resolver, "_RRM_TABLE", "rrm"),
+            patch.object(role_resolver, "DynamoDBDAO", return_value=dao),
+        ):
+            resolve_profile("u", [], namespace=_NS)
+
+        dao.query_all.assert_called()
+        dao.query.assert_not_called()
 
 
 @pytest.mark.unit

--- a/packages/context-manager/tests/unit/test_role_resolver.py
+++ b/packages/context-manager/tests/unit/test_role_resolver.py
@@ -183,6 +183,51 @@ class TestMergeDataRestrictions:
         assert resolved.table_allowlist is None
         assert resolved.column_denylist is None
 
+    # ── GLOBAL grants must not relax namespace-scoped data restrictions ──────
+    # A platform grant (platform-admin / platform-viewer) is written with
+    # resourceId="GLOBAL" and carries no tableAllowlist/columnDenylist. It must
+    # NOT enter the per-namespace restriction merge: the "grant without a
+    # restriction means unrestricted" rule would otherwise erase the namespace
+    # grant's restrictions and the SQL firewall would stop enforcing them.
+
+    def test_global_grant_does_not_erase_column_denylist(self):
+        resolved = self._resolve(
+            [
+                {"role": "data-analyst", "resourceId": _NS, "columnDenylist": {"customers": ["ssn"]}},
+                {"role": "platform-viewer", "resourceId": "GLOBAL"},  # no restriction fields
+            ]
+        )
+        assert resolved.column_denylist == {"customers": ["ssn"]}
+
+    def test_global_grant_does_not_erase_table_allowlist(self):
+        resolved = self._resolve(
+            [
+                {"role": "data-analyst", "resourceId": _NS, "tableAllowlist": ["customers"]},
+                {"role": "platform-viewer", "resourceId": "GLOBAL"},
+            ]
+        )
+        assert resolved.table_allowlist == ["customers"]
+
+    def test_global_grant_does_not_erase_allowed_metrics(self):
+        resolved = self._resolve(
+            [
+                {"role": "data-analyst", "resourceId": _NS, "allowedMetrics": ["m1"]},
+                {"role": "platform-viewer", "resourceId": "GLOBAL"},
+            ]
+        )
+        assert resolved.allowed_metrics == ["m1"]
+
+    def test_global_grant_still_resolves_into_global_roles(self):
+        """Scoping the data merge must not affect Cedar-level platform privileges."""
+        resolved = self._resolve(
+            [
+                {"role": "data-analyst", "resourceId": _NS, "columnDenylist": {"customers": ["ssn"]}},
+                {"role": "platform-viewer", "resourceId": "GLOBAL"},
+            ]
+        )
+        assert resolved.global_roles == ["platform-viewer"]
+        assert resolved.column_denylist == {"customers": ["ssn"]}
+
 
 @pytest.mark.unit
 class TestInjectInto:

--- a/packages/control-plane/src/coa_control_plane/authorization/handler.py
+++ b/packages/control-plane/src/coa_control_plane/authorization/handler.py
@@ -267,7 +267,13 @@ def _resolve_roles(
 
     for pk in principal_keys:
         try:
-            result = dao.query(
+            # query_all, not query: a single query returns one 1 MB page, so a
+            # principal whose grants span more than that would have the roles on
+            # later pages silently dropped — yielding a 403 on a namespace the
+            # user holds a valid grant for. Page boundaries depend on internal
+            # item ordering, so which roles vanish can change between
+            # invocations, making it look intermittent and unreproducible.
+            items = dao.query_all(
                 QueryParams(
                     key_condition="#pk = :pk",
                     expression_values={":pk": pk},
@@ -278,7 +284,7 @@ def _resolve_roles(
         except Exception:
             logger.exception("Failed to query roles", principal_key=pk)
             raise
-        for item in result.items:
+        for item in items:
             role = item.get("role", "")
             resource_id = item.get("resourceId", "")
             if resource_id == "GLOBAL" and role:

--- a/packages/control-plane/src/coa_control_plane/grants/list_principal_grants_handler.py
+++ b/packages/control-plane/src/coa_control_plane/grants/list_principal_grants_handler.py
@@ -113,7 +113,10 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:  # noqa: ARG
         grants: list[dict[str, Any]] = []
 
         for pk in principal_keys:
-            result = mappings_dao.query(
+            # query_all, not query: a single query returns one 1 MB page, so a
+            # principal with many grants would see an arbitrary subset of their
+            # own permissions here — with no indication the list is incomplete.
+            items = mappings_dao.query_all(
                 QueryParams(
                     key_condition="#pk = :pk",
                     expression_values={":pk": pk},
@@ -121,7 +124,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:  # noqa: ARG
                     index_name="PrincipalIndex",
                 )
             )
-            for item in result.items:
+            for item in items:
                 summary = _to_grant_summary(item)
                 if summary["grantId"] not in seen_grant_ids:
                     seen_grant_ids.add(summary["grantId"])

--- a/packages/control-plane/src/coa_control_plane/namespace/list_handler.py
+++ b/packages/control-plane/src/coa_control_plane/namespace/list_handler.py
@@ -249,7 +249,10 @@ def resolve_accessible_namespace_ids(
 
     namespace_ids: set[str] = set()
     for pk in principal_keys:
-        result = mappings_dao.query(
+        # query_all, not query: one query returns a single 1 MB page, so a
+        # principal with many grants would have the namespaces on later pages
+        # omitted from every caller's view of "what this user can reach".
+        items = mappings_dao.query_all(
             QueryParams(
                 key_condition="#pk = :pk AND begins_with(#sk, :prefix)",
                 expression_values={":pk": pk, ":prefix": f"{ResourceType.NAMESPACE}::"},
@@ -257,7 +260,7 @@ def resolve_accessible_namespace_ids(
                 index_name="PrincipalIndex",
             )
         )
-        for item in result.items:
+        for item in items:
             namespace_ids.add(item["resourceId"])
 
     return namespace_ids

--- a/packages/control-plane/tests/unit/test_authorizer_handler.py
+++ b/packages/control-plane/tests/unit/test_authorizer_handler.py
@@ -168,9 +168,9 @@ class TestRolesCaching:
         from coa_control_plane.authorization.handler import _resolve_roles, _roles_cache
 
         mock_dao = MagicMock()
-        mock_dao.query.side_effect = [
-            MagicMock(items=[{"role": "ADMIN", "resourceId": "GLOBAL"}]),
-            MagicMock(items=[{"role": "data-steward", "resourceId": "ns-123"}]),
+        mock_dao.query_all.side_effect = [
+            [{"role": "ADMIN", "resourceId": "GLOBAL"}],
+            [{"role": "data-steward", "resourceId": "ns-123"}],
         ]
 
         global_roles, resource_roles = _resolve_roles("user@example.com", ["Admins"], mock_dao)
@@ -190,12 +190,12 @@ class TestRolesCaching:
         from coa_control_plane.authorization.handler import _resolve_roles
 
         mock_dao = MagicMock()
-        mock_dao.query.return_value = MagicMock(items=[])
+        mock_dao.query_all.return_value = []
 
         _resolve_roles("foo+123@amazon.com", [], mock_dao)
 
         # Verify the query was made with URL-encoded principal ID
-        query_call = mock_dao.query.call_args_list[0]
+        query_call = mock_dao.query_all.call_args_list[0]
         query_params = query_call[0][0]
         assert query_params.expression_values[":pk"] == "User::foo%2B123@amazon.com"
 
@@ -211,13 +211,13 @@ class TestRolesCaching:
 
         assert global_roles == ["VIEWER"]
         assert resource_roles == [{"role": "data-analyst", "resourceUID": "ns-456"}]
-        mock_dao.query.assert_not_called()
+        mock_dao.query_all.assert_not_called()
 
     def test_cache_key_groups_sorted(self, env_vars):
         from coa_control_plane.authorization.handler import _resolve_roles, _roles_cache
 
         mock_dao = MagicMock()
-        mock_dao.query.return_value = MagicMock(items=[])
+        mock_dao.query_all.return_value = []
 
         _resolve_roles("user@example.com", ["GroupB", "GroupA"], mock_dao)
 
@@ -234,15 +234,15 @@ class TestRolesCaching:
 
         mock_dao = MagicMock()
         # User query returns a role, group query returns nothing
-        mock_dao.query.side_effect = [
-            MagicMock(items=[{"role": "VIEWER", "resourceId": "GLOBAL"}]),
-            MagicMock(items=[]),
+        mock_dao.query_all.side_effect = [
+            [{"role": "VIEWER", "resourceId": "GLOBAL"}],
+            [],
         ]
 
         global_roles, resource_roles = _resolve_roles("user@example.com", ["GroupX"], mock_dao)
 
         # Should have queried DDB since cache was corrupt
-        assert mock_dao.query.called
+        assert mock_dao.query_all.called
         assert global_roles == ["VIEWER"]
         # Cache population disabled — entry should not exist after eviction
         assert cache_key not in _roles_cache

--- a/packages/control-plane/tests/unit/test_list_namespaces.py
+++ b/packages/control-plane/tests/unit/test_list_namespaces.py
@@ -90,11 +90,11 @@ class TestResolveAccessibleNamespaceIds:
         from coa_control_plane.namespace.list_handler import resolve_accessible_namespace_ids
 
         mappings_dao = MagicMock()
-        mappings_dao.query.return_value = PaginatedResult(items=[])
+        mappings_dao.query_all.return_value = []
 
         resolve_accessible_namespace_ids(mappings_dao, "foo+123@co.com", ["group/eng"])
 
-        queried_pks = [call.args[0].expression_values[":pk"] for call in mappings_dao.query.call_args_list]
+        queried_pks = [call.args[0].expression_values[":pk"] for call in mappings_dao.query_all.call_args_list]
         assert "User::foo%2B123@co.com" in queried_pks
         assert "Group::group%2Feng" in queried_pks
 
@@ -256,9 +256,9 @@ class TestScopedUser:
         mock_mappings_dao = MagicMock()
         mock_dao_cls.side_effect = [mock_ns_dao, mock_mappings_dao]
 
-        mock_mappings_dao.query.return_value = PaginatedResult(
-            items=[{"resourceType": "Namespace", "resourceId": "11111111-1111-1111-1111-111111111111", "role": "owner"}]
-        )
+        mock_mappings_dao.query_all.return_value = [
+            {"resourceType": "Namespace", "resourceId": "11111111-1111-1111-1111-111111111111", "role": "owner"}
+        ]
         mock_ns_dao.batch_get.return_value = [NS_ITEM]
 
         resp = handler(_event(user_id="alice@co.com"), None)
@@ -274,7 +274,7 @@ class TestScopedUser:
         mock_mappings_dao = MagicMock()
         mock_dao_cls.side_effect = [mock_ns_dao, mock_mappings_dao]
 
-        mock_mappings_dao.query.return_value = PaginatedResult(items=[])
+        mock_mappings_dao.query_all.return_value = []
 
         resp = handler(_event(user_id="nobody@co.com"), None)
 
@@ -288,17 +288,15 @@ class TestScopedUser:
         mock_mappings_dao = MagicMock()
         mock_dao_cls.side_effect = [mock_ns_dao, mock_mappings_dao]
 
-        mock_mappings_dao.query.side_effect = [
-            PaginatedResult(items=[]),
-            PaginatedResult(
-                items=[
-                    {
-                        "resourceType": "Namespace",
-                        "resourceId": "22222222-2222-2222-2222-222222222222",
-                        "role": "data-steward",
-                    }
-                ]
-            ),
+        mock_mappings_dao.query_all.side_effect = [
+            [],
+            [
+                {
+                    "resourceType": "Namespace",
+                    "resourceId": "22222222-2222-2222-2222-222222222222",
+                    "role": "data-steward",
+                }
+            ],
         ]
         mock_ns_dao.batch_get.return_value = [NS_ITEM_2]
 
@@ -315,21 +313,15 @@ class TestScopedUser:
         mock_mappings_dao = MagicMock()
         mock_dao_cls.side_effect = [mock_ns_dao, mock_mappings_dao]
 
-        mock_mappings_dao.query.side_effect = [
-            PaginatedResult(
-                items=[
-                    {"resourceType": "Namespace", "resourceId": "11111111-1111-1111-1111-111111111111", "role": "owner"}
-                ]
-            ),
-            PaginatedResult(
-                items=[
-                    {
-                        "resourceType": "Namespace",
-                        "resourceId": "11111111-1111-1111-1111-111111111111",
-                        "role": "data-steward",
-                    }
-                ]
-            ),
+        mock_mappings_dao.query_all.side_effect = [
+            [{"resourceType": "Namespace", "resourceId": "11111111-1111-1111-1111-111111111111", "role": "owner"}],
+            [
+                {
+                    "resourceType": "Namespace",
+                    "resourceId": "11111111-1111-1111-1111-111111111111",
+                    "role": "data-steward",
+                }
+            ],
         ]
         mock_ns_dao.batch_get.return_value = [NS_ITEM]
 
@@ -349,13 +341,11 @@ class TestScopedUser:
         mock_dao_cls.side_effect = [mock_ns_dao, mock_mappings_dao]
 
         # User has access to 3 namespaces
-        mock_mappings_dao.query.return_value = PaginatedResult(
-            items=[
-                {"resourceType": "Namespace", "resourceId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "role": "owner"},
-                {"resourceType": "Namespace", "resourceId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "role": "owner"},
-                {"resourceType": "Namespace", "resourceId": "cccccccc-cccc-cccc-cccc-cccccccccccc", "role": "owner"},
-            ]
-        )
+        mock_mappings_dao.query_all.return_value = [
+            {"resourceType": "Namespace", "resourceId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "role": "owner"},
+            {"resourceType": "Namespace", "resourceId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "role": "owner"},
+            {"resourceType": "Namespace", "resourceId": "cccccccc-cccc-cccc-cccc-cccccccccccc", "role": "owner"},
+        ]
         mock_ns_dao.batch_get.return_value = [
             {
                 **NS_ITEM,
@@ -387,13 +377,11 @@ class TestScopedUser:
 
         # Request page 2 using the token
         mock_dao_cls.side_effect = [mock_ns_dao, mock_mappings_dao]
-        mock_mappings_dao.query.return_value = PaginatedResult(
-            items=[
-                {"resourceType": "Namespace", "resourceId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "role": "owner"},
-                {"resourceType": "Namespace", "resourceId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "role": "owner"},
-                {"resourceType": "Namespace", "resourceId": "cccccccc-cccc-cccc-cccc-cccccccccccc", "role": "owner"},
-            ]
-        )
+        mock_mappings_dao.query_all.return_value = [
+            {"resourceType": "Namespace", "resourceId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "role": "owner"},
+            {"resourceType": "Namespace", "resourceId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "role": "owner"},
+            {"resourceType": "Namespace", "resourceId": "cccccccc-cccc-cccc-cccc-cccccccccccc", "role": "owner"},
+        ]
         resp2 = handler(
             _event(user_id="alice@co.com", query_params={"maxResults": "2", "nextToken": body["nextToken"]}),
             None,
@@ -410,14 +398,14 @@ class TestScopedUser:
         mock_mappings_dao = MagicMock()
         mock_dao_cls.side_effect = [mock_ns_dao, mock_mappings_dao]
 
-        mock_mappings_dao.query.return_value = PaginatedResult(
-            items=[{"resourceType": "Namespace", "resourceId": "11111111-1111-1111-1111-111111111111", "role": "owner"}]
-        )
+        mock_mappings_dao.query_all.return_value = [
+            {"resourceType": "Namespace", "resourceId": "11111111-1111-1111-1111-111111111111", "role": "owner"}
+        ]
         mock_ns_dao.batch_get.return_value = [NS_ITEM]
 
         handler(_event(user_id="alice@co.com"), None)
 
-        call_args = mock_mappings_dao.query.call_args[0][0]
+        call_args = mock_mappings_dao.query_all.call_args[0][0]
         assert "begins_with" in call_args.key_condition
         assert call_args.expression_values[":prefix"] == "Namespace::"
 

--- a/packages/control-plane/tests/unit/test_list_principal_grants.py
+++ b/packages/control-plane/tests/unit/test_list_principal_grants.py
@@ -10,7 +10,6 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
-from coa_common.dao import PaginatedResult
 
 os.environ.update(
     {
@@ -63,21 +62,18 @@ class TestListPrincipalGrants:
     def test_lists_grants_for_self(self, mock_dao_cls):
         mock_dao = MagicMock()
         mock_dao_cls.return_value = mock_dao
-        mock_dao.query.return_value = PaginatedResult(
-            items=[
-                {
-                    "PK": f"Namespace::{VALID_NS_ID}#User::alice@company.com",
-                    "SK": "ROLE#analyst",
-                    "resourceId": VALID_NS_ID,
-                    "principalType": "User",
-                    "principalId": "alice@company.com",
-                    "role": "analyst",
-                    "grantedBy": "bob@company.com",
-                    "grantedAt": "2026-04-09T10:00:00Z",
-                },
-            ],
-            last_evaluated_key=None,
-        )
+        mock_dao.query_all.return_value = [
+            {
+                "PK": f"Namespace::{VALID_NS_ID}#User::alice@company.com",
+                "SK": "ROLE#analyst",
+                "resourceId": VALID_NS_ID,
+                "principalType": "User",
+                "principalId": "alice@company.com",
+                "role": "analyst",
+                "grantedBy": "bob@company.com",
+                "grantedAt": "2026-04-09T10:00:00Z",
+            },
+        ]
 
         resp = handler(_event_me(), None)
         assert resp["statusCode"] == 200
@@ -86,7 +82,7 @@ class TestListPrincipalGrants:
         assert body["grants"][0]["role"] == "analyst"
 
         # Verify PrincipalIndex GSI was used with sanitized email
-        query_call = mock_dao.query.call_args[0][0]
+        query_call = mock_dao.query_all.call_args[0][0]
         assert query_call.index_name == "PrincipalIndex"
         assert ":pk" in query_call.expression_values
         assert query_call.expression_values[":pk"] == "User::alice@company.com"
@@ -95,14 +91,14 @@ class TestListPrincipalGrants:
     def test_queries_user_and_groups(self, mock_dao_cls):
         mock_dao = MagicMock()
         mock_dao_cls.return_value = mock_dao
-        mock_dao.query.return_value = PaginatedResult(items=[], last_evaluated_key=None)
+        mock_dao.query_all.return_value = []
 
         resp = handler(_event_me("alice@co.com", "admins,viewers"), None)
         assert resp["statusCode"] == 200
 
         # Should query 3 times: User + 2 groups
-        assert mock_dao.query.call_count == 3
-        keys_queried = [call[0][0].expression_values[":pk"] for call in mock_dao.query.call_args_list]
+        assert mock_dao.query_all.call_count == 3
+        keys_queried = [call[0][0].expression_values[":pk"] for call in mock_dao.query_all.call_args_list]
         assert "User::alice@co.com" in keys_queried
         assert "Group::admins" in keys_queried
         assert "Group::viewers" in keys_queried
@@ -122,7 +118,7 @@ class TestListPrincipalGrants:
             "grantedBy": "admin@co.com",
             "grantedAt": "2026-05-01T00:00:00Z",
         }
-        mock_dao.query.return_value = PaginatedResult(items=[grant_item], last_evaluated_key=None)
+        mock_dao.query_all.return_value = [grant_item]
 
         resp = handler(_event_me("alice@co.com", "team"), None)
         body = json.loads(resp["body"])
@@ -133,46 +129,46 @@ class TestListPrincipalGrants:
     def test_normalizes_email_to_lowercase(self, mock_dao_cls):
         mock_dao = MagicMock()
         mock_dao_cls.return_value = mock_dao
-        mock_dao.query.return_value = PaginatedResult(items=[], last_evaluated_key=None)
+        mock_dao.query_all.return_value = []
 
         resp = handler(_event_me("Alice@Company.COM"), None)
         assert resp["statusCode"] == 200
 
-        key = mock_dao.query.call_args[0][0].expression_values[":pk"]
+        key = mock_dao.query_all.call_args[0][0].expression_values[":pk"]
         assert key == "User::alice@company.com"
 
     @patch("coa_control_plane.grants.list_principal_grants_handler.DynamoDBDAO")
     def test_limits_groups_to_max(self, mock_dao_cls):
         mock_dao = MagicMock()
         mock_dao_cls.return_value = mock_dao
-        mock_dao.query.return_value = PaginatedResult(items=[], last_evaluated_key=None)
+        mock_dao.query_all.return_value = []
 
         many_groups = ",".join(f"group{i}" for i in range(20))
         resp = handler(_event_me("a@b.com", many_groups), None)
         assert resp["statusCode"] == 200
         # 1 user + max 10 groups = 11 queries
-        assert mock_dao.query.call_count == 11
+        assert mock_dao.query_all.call_count == 11
 
     @patch("coa_control_plane.grants.list_principal_grants_handler.DynamoDBDAO")
     def test_skips_invalid_group_names(self, mock_dao_cls):
         mock_dao = MagicMock()
         mock_dao_cls.return_value = mock_dao
-        mock_dao.query.return_value = PaginatedResult(items=[], last_evaluated_key=None)
+        mock_dao.query_all.return_value = []
 
         resp = handler(_event_me("a@b.com", "valid-group,bad::group,ok_group"), None)
         assert resp["statusCode"] == 200
         # 1 user + 2 valid groups (bad::group skipped)
-        assert mock_dao.query.call_count == 3
+        assert mock_dao.query_all.call_count == 3
 
     @patch("coa_control_plane.grants.list_principal_grants_handler.DynamoDBDAO")
     def test_fallback_to_claims_email(self, mock_dao_cls):
         mock_dao = MagicMock()
         mock_dao_cls.return_value = mock_dao
-        mock_dao.query.return_value = PaginatedResult(items=[], last_evaluated_key=None)
+        mock_dao.query_all.return_value = []
 
         resp = handler(_event_me_claims("bob@co.com", "devs"), None)
         assert resp["statusCode"] == 200
-        key = mock_dao.query.call_args_list[0][0][0].expression_values[":pk"]
+        key = mock_dao.query_all.call_args_list[0][0][0].expression_values[":pk"]
         assert key == "User::bob@co.com"
 
     def test_rejects_non_me_principal(self):
@@ -207,7 +203,7 @@ class TestListPrincipalGrants:
     def test_dynamo_error_returns_500(self, mock_dao_cls):
         mock_dao = MagicMock()
         mock_dao_cls.return_value = mock_dao
-        mock_dao.query.side_effect = Exception("DynamoDB throttled")
+        mock_dao.query_all.side_effect = Exception("DynamoDB throttled")
 
         resp = handler(_event_me(), None)
         assert resp["statusCode"] == 500
@@ -238,7 +234,7 @@ class TestListPrincipalGrantsToGrantSummary:
             "columnDenylist": {"customers": ["ssn", "dob"]},
             "allowedMetrics": ["revenue", "order_count"],
         }
-        mock_dao.query.return_value = PaginatedResult(items=[item], last_evaluated_key=None)
+        mock_dao.query_all.return_value = [item]
         resp = handler(_event_me(), None)
         body = json.loads(resp["body"])
         grant = body["grants"][0]
@@ -251,7 +247,7 @@ class TestListPrincipalGrantsToGrantSummary:
     def test_overrides_absent_are_omitted(self, mock_dao_cls):
         mock_dao = MagicMock()
         mock_dao_cls.return_value = mock_dao
-        mock_dao.query.return_value = PaginatedResult(items=[self.BASE_ITEM], last_evaluated_key=None)
+        mock_dao.query_all.return_value = [self.BASE_ITEM]
         resp = handler(_event_me(), None)
         body = json.loads(resp["body"])
         grant = body["grants"][0]
@@ -270,7 +266,7 @@ class TestListPrincipalGrantsToGrantSummary:
             "columnDenylist": {},
             "allowedMetrics": [],
         }
-        mock_dao.query.return_value = PaginatedResult(items=[item], last_evaluated_key=None)
+        mock_dao.query_all.return_value = [item]
         resp = handler(_event_me(), None)
         body = json.loads(resp["body"])
         grant = body["grants"][0]
@@ -283,7 +279,7 @@ class TestListPrincipalGrantsToGrantSummary:
         mock_dao = MagicMock()
         mock_dao_cls.return_value = mock_dao
         item = {**self.BASE_ITEM, "columnDenylist": {"customers": ["ssn"]}}
-        mock_dao.query.return_value = PaginatedResult(items=[item], last_evaluated_key=None)
+        mock_dao.query_all.return_value = [item]
         resp = handler(_event_me(), None)
         body = json.loads(resp["body"])
         grant = body["grants"][0]

--- a/packages/mcp-server/src/coa_mcp/auth/grant_resolver.py
+++ b/packages/mcp-server/src/coa_mcp/auth/grant_resolver.py
@@ -192,25 +192,28 @@ async def resolve_grant(
             namespace=namespace_id,
         )
     except Exception as e:
-        # If role resolution fails but user is admin, allow with empty restrictions
-        if "Admin" in caller.roles or "admin" in caller.roles:
-            logger.warning(
-                "grant_resolution_failed_admin_fallback",
-                user_id=caller.user_id,
-                namespace=namespace_id,
-                error=str(e),
-            )
-            return ResolvedProfile(
-                namespace=namespace_id,
-                user_id=caller.user_id,
-                global_roles=["platform-admin"],
-                resource_roles=[{"role": "namespace-owner", "resourceUID": namespace_id}],
-            )
-
+        # Fail closed for EVERY caller, admins included.
+        #
+        # There used to be an admin fallback here that returned platform-admin +
+        # namespace-owner and returned EARLY — before the Cedar evaluation below,
+        # despite that block's comment claiming it is never bypassed. It granted
+        # those roles off nothing but an "admin" entry in the caller's IdP groups,
+        # with no policy check and no data restrictions.
+        #
+        # It was near-unreachable while resolve_profile swallowed its own query
+        # errors, but that method now propagates them (a partial grant read is more
+        # permissive than the truth, so degrading there widened data access). A
+        # DynamoDB throttle would therefore have escalated any admin-group caller.
+        #
+        # A failed grant read means we do not know what this caller may do, which is
+        # never a reason to assume the most privileged answer. Denying turns a
+        # transient backend error into a retryable failure instead of a silent
+        # privilege escalation.
         logger.error(
             "grant_resolution_failed",
             user_id=caller.user_id,
             namespace=namespace_id,
+            is_admin_group_member=any(r.lower() == "admin" for r in caller.roles),
             error=str(e),
         )
         raise GrantResolutionError(f"Failed to resolve grant for user '{caller.user_id}': {e}") from e

--- a/packages/mcp-server/tests/unit/test_grant_resolver.py
+++ b/packages/mcp-server/tests/unit/test_grant_resolver.py
@@ -236,29 +236,46 @@ class TestCedarEvaluation:
 class TestRoleResolutionFailure:
     """Behavior when the shared role_resolver raises."""
 
+    # An admin caller used to get platform-admin + namespace-owner here, returned
+    # EARLY — before the Cedar evaluation — off nothing but an "admin" entry in
+    # their IdP groups. A failed grant read means we do not know what the caller
+    # may do, which is never a reason to assume the most privileged answer. The
+    # path also became reachable once resolve_profile stopped swallowing its query
+    # errors, so a DynamoDB throttle would have escalated any admin-group caller.
+
     @pytest.mark.asyncio
     @patch("coa_serve.role_resolver.resolve_profile")
-    async def test_admin_role_falls_back_to_owner_profile(self, mock_resolve):
-        """When role resolution fails but caller is admin, allow with owner profile."""
+    async def test_admin_role_resolution_failure_raises(self, mock_resolve):
+        """Admins fail closed too — no privilege escalation on a backend error."""
         mock_resolve.side_effect = RuntimeError("RRM table unavailable")
         caller = _make_caller(user_id="root", namespaces=["sales"], roles=["Admin"])
 
-        profile = await resolve_grant(caller, "sales")
-
-        assert profile.namespace == "sales"
-        assert profile.user_id == "root"
-        assert profile.global_roles == ["platform-admin"]
-        assert profile.resource_roles == [{"role": "namespace-owner", "resourceUID": "sales"}]
+        with pytest.raises(GrantResolutionError, match="Failed to resolve grant"):
+            await resolve_grant(caller, "sales")
 
     @pytest.mark.asyncio
     @patch("coa_serve.role_resolver.resolve_profile")
-    async def test_lowercase_admin_role_falls_back(self, mock_resolve):
+    async def test_lowercase_admin_role_also_fails_closed(self, mock_resolve):
         mock_resolve.side_effect = RuntimeError("boom")
         caller = _make_caller(user_id="root", namespaces=["sales"], roles=["admin"])
 
-        profile = await resolve_grant(caller, "sales")
+        with pytest.raises(GrantResolutionError, match="Failed to resolve grant"):
+            await resolve_grant(caller, "sales")
 
-        assert profile.global_roles == ["platform-admin"]
+    @pytest.mark.asyncio
+    @patch("coa_serve.role_resolver.resolve_profile")
+    async def test_failure_never_returns_a_profile_that_skips_cedar(self, mock_resolve):
+        """The escalation was worse than its roles: it returned before Cedar ran."""
+        mock_resolve.side_effect = RuntimeError("throttled")
+        caller = _make_caller(user_id="root", namespaces=["sales"], roles=["Admin"])
+
+        with (
+            patch("coa_mcp.auth.grant_resolver._evaluate_cedar") as mock_cedar,
+            pytest.raises(GrantResolutionError),
+        ):
+            await resolve_grant(caller, "sales")
+
+        mock_cedar.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("coa_serve.role_resolver.resolve_profile")

--- a/packages/metric-service/tests/unit/test_constants.py
+++ b/packages/metric-service/tests/unit/test_constants.py
@@ -35,7 +35,13 @@ class TestInvalidDialectMessage:
     def test_unknown_dialect_has_no_hint(self):
         msg = invalid_dialect_message("ORACLE")
         assert "ORACLE" in msg
-        assert "TRINO" not in msg
+        # Assert on the absence of the HINT, not of the word "TRINO": the base
+        # message always lists every valid dialect (see
+        # test_base_message_lists_valid_dialects), TRINO among them, so
+        # `"TRINO" not in msg` can never hold and contradicted that test.
+        assert dialect_hint("ORACLE") is None
+        assert "use TRINO" not in msg
+        assert "(" not in msg, f"expected no hint suffix, got: {msg}"
 
     def test_base_message_lists_valid_dialects(self):
         msg = invalid_dialect_message("ATHENA")

--- a/packages/metric-service/tests/unit/test_validation_errors.py
+++ b/packages/metric-service/tests/unit/test_validation_errors.py
@@ -6,10 +6,11 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Annotated
 
 import pytest
 from coa_metrics.api.validation_errors import format_validation_error
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
 
 class _SqlDialect(StrEnum):
@@ -23,7 +24,11 @@ class _Dialect(BaseModel):
 
 
 class _Expression(BaseModel):
-    dialects: list[_Dialect]
+    # min_length mirrors the generated MetricExpression
+    # (smithy-generated/.../models/metric_expression.py), so an empty list raises
+    # the too_short error the tests below expect. Without it the stub accepted
+    # `dialects: []` and `_validation_error` failed with "DID NOT RAISE".
+    dialects: Annotated[list[_Dialect], Field(min_length=1)]
 
 
 class _Metric(BaseModel):
@@ -85,4 +90,8 @@ class TestFormatValidationError:
             {"name": "m1", "expression": {"dialects": [{"dialect": "ORACLE", "expression": "SUM(x)"}]}}
         )
         msg = format_validation_error(exc)
-        assert "TRINO" not in msg
+        # Assert the HINT is absent, not the word "TRINO": Pydantic's own enum
+        # error already enumerates the permitted values ("Input should be
+        # 'POSTGRESQL' or 'TRINO'"), so `"TRINO" not in msg` could never hold.
+        assert "use TRINO" not in msg
+        assert "Athena" not in msg

--- a/packages/ontology-engine/src/coa_ontology/datatype_canonicalizer.py
+++ b/packages/ontology-engine/src/coa_ontology/datatype_canonicalizer.py
@@ -40,9 +40,13 @@ This is complementary to the tier-1 HermiT substitution: that one rewrites
 
 from __future__ import annotations
 
+import logging
+
 from rdflib import Graph, Literal, URIRef
 from rdflib.namespace import XSD
 from rdflib.term import Node
+
+log = logging.getLogger(__name__)
 
 # Correctly-cased XSD datatype local names we recognize — the authoritative
 # XML Schema Part 2 built-in datatype set (https://www.w3.org/TR/xmlschema11-2/
@@ -163,34 +167,67 @@ def _canonical_for(uri: URIRef) -> URIRef | None:
     return None
 
 
+def _rewrite_is_value_safe(literal: Literal, canonical: URIRef) -> bool:
+    """True when ``literal``'s lexical form is valid for the ``canonical`` datatype.
+
+    The alias table maps SQL type names onto XSD types with far NARROWER lexical
+    spaces than the string-ish tokens they replace (``bigint`` → ``xsd:long``,
+    ``number`` → ``xsd:decimal``, ``timestamp`` → ``xsd:dateTime``). A value that
+    was legal as an opaque ``xsd:bigint``-tagged string is not necessarily legal
+    as an ``xsd:long``: rewriting the datatype alone turns ``"abc"^^xsd:bigint``
+    into the ill-typed ``"abc"^^xsd:long``.
+
+    That matters more here than it would elsewhere because this module runs at the
+    WRITE boundary. Its own docstring is explicit that corruption at that point is
+    irreversible on S3, which is why an unrecognized token is left alone — the
+    same argument applies to a recognized alias whose value does not fit, and this
+    guard extends the policy to cover it. The offending token stays as it was
+    (still opaque to HermiT, so no reasoner abort) rather than becoming a literal
+    with no value in SPARQL semantics, which silently drops out of result sets and
+    can flip an ontology to OWL 2 DL inconsistent on a later run.
+
+    Args:
+        literal: The typed literal whose datatype would be rewritten.
+        canonical: The datatype it would be rewritten to.
+
+    Returns:
+        ``False`` when the rewrite would produce an ill-typed literal.
+    """
+    return not Literal(str(literal), datatype=canonical, normalize=False).ill_typed
+
+
 def _scan_datatype_offenders(
     graph: Graph,
-) -> list[tuple[Node, Node, Node, URIRef, URIRef, bool]]:
+) -> list[tuple[Node, Node, Node, URIRef, URIRef, bool, bool]]:
     """Find every triple carrying a malformed/mis-cased/aliased XSD token.
 
     Single source of truth for BOTH detection and repair, so the two can never
     disagree about what counts as "malformed" (a datatype flagged by
-    ``detect_datatype_issues`` is exactly one ``canonicalize_datatypes`` rewrites,
-    and vice versa). A token ``_canonical_for`` leaves alone — a non-XSD URI, a
-    valid correctly-cased type (incl. ``xsd:date``), or an unknown ``xsd:`` token
-    — is neither reported nor rewritten.
+    ``detect_datatype_issues`` is exactly one ``canonicalize_datatypes``
+    considers, and vice versa). A token ``_canonical_for`` leaves alone — a
+    non-XSD URI, a valid correctly-cased type (incl. ``xsd:date``), or an unknown
+    ``xsd:`` token — is neither reported nor rewritten.
 
-    Returns tuples ``(s, p, o, found_uri, canonical_uri, is_literal)`` where
-    ``found_uri`` is the offending datatype and ``canonical_uri`` its replacement.
-    ``is_literal`` is True when the datatype sits on a typed literal object
-    (``"x"^^xsd:datetime``) rather than on a datatype-URI object
-    (``rdfs:range xsd:datetime`` / ``rr:datatype xsd:datetime``).
+    Returns tuples ``(s, p, o, found_uri, canonical_uri, is_literal,
+    value_safe)`` where ``found_uri`` is the offending datatype and
+    ``canonical_uri`` its replacement. ``is_literal`` is True when the datatype
+    sits on a typed literal object (``"x"^^xsd:datetime``) rather than on a
+    datatype-URI object (``rdfs:range xsd:datetime`` / ``rr:datatype
+    xsd:datetime``). ``value_safe`` is False when rewriting a typed literal to
+    ``canonical_uri`` would make it ill-typed — such an offender is still
+    REPORTED (the token is genuinely malformed and the user should see it) but is
+    not rewritten; see :func:`_rewrite_is_value_safe`.
     """
-    offenders: list[tuple[Node, Node, Node, URIRef, URIRef, bool]] = []
+    offenders: list[tuple[Node, Node, Node, URIRef, URIRef, bool, bool]] = []
     for s, p, o in list(graph):
         if isinstance(o, URIRef):
             canonical = _canonical_for(o)
             if canonical is not None and canonical != o:
-                offenders.append((s, p, o, o, canonical, False))
+                offenders.append((s, p, o, o, canonical, False, True))
         elif isinstance(o, Literal) and o.datatype is not None:
             canonical = _canonical_for(o.datatype)
             if canonical is not None and canonical != o.datatype:
-                offenders.append((s, p, o, o.datatype, canonical, True))
+                offenders.append((s, p, o, o.datatype, canonical, True, _rewrite_is_value_safe(o, canonical)))
     return offenders
 
 
@@ -202,12 +239,35 @@ def canonicalize_datatypes(graph: Graph) -> list[tuple[str, str]]:
     literal datatypes (``"x"^^xsd:datetime``). Returns the list of
     ``(before, after)`` URI strings that were changed (empty when the graph was
     already clean), so callers can log what they touched.
+
+    Only the datatype IRI changes: a literal's lexical form is carried over
+    verbatim, and a rewrite that would leave the literal ill-typed is SKIPPED (the
+    triple is left exactly as it was). ``detect_datatype_issues`` still reports
+    those tokens, so they remain visible to the user even though this function
+    declines to touch them.
     """
     changes: list[tuple[str, str]] = []
-    for s, p, o, found, canonical, is_literal in _scan_datatype_offenders(graph):
+    for s, p, o, found, canonical, is_literal, value_safe in _scan_datatype_offenders(graph):
+        if not value_safe:
+            # Rewriting would produce an ill-typed literal. Leave the token alone:
+            # this runs at the persist boundary, so the corruption would be
+            # irreversible on S3 — the same reason unrecognized tokens are left
+            # untouched. An unknown xsd: URI stays opaque to HermiT (no reasoner
+            # abort), whereas an ill-typed literal has no value in SPARQL
+            # semantics and can flip the ontology to OWL 2 DL inconsistent.
+            log.warning(
+                "datatype_alias_incompatible_with_value",
+                extra={"found": str(found), "canonical": str(canonical), "subject": str(s), "predicate": str(p)},
+            )
+            continue
         graph.remove((s, p, o))
         if is_literal:
-            graph.add((s, p, Literal(str(o), datatype=canonical)))
+            # normalize=False is load-bearing: constructing a Literal with a
+            # datatype rdflib understands rewrites the lexical form to that
+            # datatype's canonical spelling, so a timestamp→dateTime repair
+            # silently turned "2024-01-15" into "2024-01-15T00:00:00". This
+            # function repairs the TOKEN; the value must survive byte-for-byte.
+            graph.add((s, p, Literal(str(o), datatype=canonical, normalize=False)))
         else:
             graph.add((s, p, canonical))
         changes.append((str(found), str(canonical)))
@@ -220,13 +280,27 @@ def detect_datatype_issues(graph: Graph) -> list[dict[str, str]]:
     Read-only counterpart to :func:`canonicalize_datatypes`, used by the
     validator to surface offending tokens to the user (who then consents to a
     repair) rather than rewriting them silently. Returns one dict per offending
-    triple: ``{subject, predicate, found, canonical}`` — the subject/predicate
-    locate the offending element, ``found`` is the malformed datatype IRI and
-    ``canonical`` its proposed replacement. Empty when the graph is clean.
+    triple: ``{subject, predicate, found, canonical, repairable}`` — the
+    subject/predicate locate the offending element, ``found`` is the malformed
+    datatype IRI and ``canonical`` its proposed replacement. Empty when the graph
+    is clean.
+
+    ``repairable`` is ``"false"`` when the token is malformed but the repair would
+    leave the literal ill-typed (e.g. ``"abc"^^xsd:bigint`` → ``xsd:long``), in
+    which case :func:`canonicalize_datatypes` deliberately leaves the triple
+    alone. Such offenders are still reported: the token IS wrong and the user
+    should see it, they just need to fix the value rather than consent to a
+    mechanical rewrite.
     """
     return [
-        {"subject": str(s), "predicate": str(p), "found": str(found), "canonical": str(canonical)}
-        for s, p, _o, found, canonical, _is_literal in _scan_datatype_offenders(graph)
+        {
+            "subject": str(s),
+            "predicate": str(p),
+            "found": str(found),
+            "canonical": str(canonical),
+            "repairable": "true" if value_safe else "false",
+        }
+        for s, p, _o, found, canonical, _is_literal, value_safe in _scan_datatype_offenders(graph)
     ]
 
 

--- a/packages/ontology-engine/src/coa_ontology/dynamo_store.py
+++ b/packages/ontology-engine/src/coa_ontology/dynamo_store.py
@@ -1329,16 +1329,32 @@ def get_namespace_meta(namespace: str) -> dict | None:
 def list_namespaces(limit: int = 100) -> list[dict]:
     """Return every namespace META row.
 
-    Uses a Scan with filter on ``SK = "META"`` and ``begins_with(PK, "NAMESPACE#")``.
-    For small deployments (dozens of namespaces) this is fine; add a GSI
-    later if the namespace count grows past a few hundred.
+    Scans with a filter on ``SK = "META"`` and ``begins_with(PK, "NAMESPACE#")``,
+    following ``LastEvaluatedKey`` until ``limit`` matches are collected or the
+    table is exhausted.
+
+    The pagination is NOT about the namespace count. DynamoDB applies ``Limit`` to
+    the number of items **evaluated before filtering**, not to matches returned,
+    and this single-table design stores job, proposal, and ingest-job rows
+    alongside the ``NAMESPACE#`` ones. With more than ``limit`` such rows — normal
+    after modest usage — the first scanned page can contain few or zero namespace
+    rows, and a single-page read simply omitted the rest with no error. ``list_jobs``
+    / ``list_proposals`` / ``list_ingest_jobs`` in this module already paginate for
+    exactly this reason; this path was the one left behind.
     """
-    resp = _get_table().scan(
-        FilterExpression="begins_with(PK, :p) AND SK = :sk",
-        ExpressionAttributeValues={":p": "NAMESPACE#", ":sk": "META"},
-        Limit=limit,
-    )
-    return resp.get("Items", [])
+    kwargs: dict = {
+        "FilterExpression": "begins_with(PK, :p) AND SK = :sk",
+        "ExpressionAttributeValues": {":p": "NAMESPACE#", ":sk": "META"},
+    }
+    items: list[dict] = []
+    while len(items) < limit:
+        resp = _get_table().scan(**kwargs)
+        items.extend(resp.get("Items", []))
+        last_key = resp.get("LastEvaluatedKey")
+        if not last_key:
+            break
+        kwargs["ExclusiveStartKey"] = last_key
+    return items[:limit]
 
 
 def put_ontology_registry(namespace: str, ontology_id: str, data: dict) -> dict:

--- a/packages/ontology-engine/src/coa_ontology/induce_catalog.py
+++ b/packages/ontology-engine/src/coa_ontology/induce_catalog.py
@@ -122,9 +122,12 @@ def _compute_structural_fingerprint(tables) -> str:
     import hashlib
 
     def _norm_ref(ref: str) -> str:
-        # Keep only the trailing table.column (drop catalog/db qualifiers).
-        parts = ref.split(".")
-        return ".".join(parts[-2:]) if len(parts) >= 2 else ref
+        # Keep only the trailing table.column (drop catalog/db qualifiers), using
+        # the one shared parser so the fingerprint agrees with every consumer.
+        from coa_ontology.inducer.services.data_catalog import parse_referred_column
+
+        table, column = parse_referred_column(ref)
+        return f"{table}.{column}" if column is not None else table
 
     parts = []
     for t in sorted(tables, key=lambda x: x.name):

--- a/packages/ontology-engine/src/coa_ontology/inducer/services/data_catalog.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/services/data_catalog.py
@@ -34,6 +34,45 @@ class CatalogConstraint(BaseModel):
     relationshipType: str | None = None
 
 
+def parse_referred_column(ref: str) -> tuple[str, str | None]:
+    """Split a ``referredColumns`` entry into ``(target_table, target_column)``.
+
+    The catalog reports an FK target as a dotted identifier whose LAST TWO
+    segments are ``TABLE.COLUMN``. Everything before them is qualification
+    (database, schema, catalog) and is dropped:
+
+        ``"orders.order_id"``               → ``("orders", "order_id")``
+        ``"public.orders.order_id"``        → ``("orders", "order_id")``
+        ``"db.public.orders.order_id"``     → ``("orders", "order_id")``
+        ``"orders"``                        → ``("orders", None)``
+
+    A single-segment value carries no column, so the caller cannot build a
+    join condition from it — ``build_r2rml`` treats that as a plain datatype
+    column rather than emitting a bare ``rr:parentTriplesMap``, which would make
+    Ontop produce a Cartesian product (R2RML §7.5).
+
+    This lives here, next to :class:`CatalogConstraint`, because the rule was
+    previously re-implemented at six call sites under TWO INCOMPATIBLE
+    conventions: ``parts[0]`` in the R2RML builder and the RIGOR topological sort,
+    ``parts[-2]`` in the ontology builder, the SHACL config generator, the subtype
+    detector, and the fingerprint normalizer. For a three-part reference the
+    former yields the SCHEMA name, so the mapping pointed ``rr:parentTriplesMap``
+    at a TriplesMap that does not exist while the ontology and shapes correctly
+    referenced the table — the artifacts described different graphs.
+
+    Args:
+        ref: A ``referredColumns`` entry.
+
+    Returns:
+        ``(target_table, target_column)``; ``target_column`` is ``None`` when
+        ``ref`` has no dot.
+    """
+    parts = ref.split(".")
+    if len(parts) >= 2:
+        return parts[-2], parts[-1]
+    return ref, None
+
+
 class CatalogTable(BaseModel):
     """A table from the data catalog, with its columns, constraints, and datasource."""
 

--- a/packages/ontology-engine/src/coa_ontology/inducer/services/subtype_detection.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/services/subtype_detection.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import logging
 
-from coa_ontology.inducer.services.data_catalog import CatalogTable
+from coa_ontology.inducer.services.data_catalog import CatalogTable, parse_referred_column
 
 logger = logging.getLogger(__name__)
 
@@ -55,11 +55,9 @@ def _single_col_fks(table: CatalogTable) -> list[tuple[str, str, str]]:
             continue
         if not tc.referredColumns or len(tc.referredColumns) != 1:
             continue
-        parts = tc.referredColumns[0].split(".")
-        if len(parts) < 2:
-            continue
-        parent_table = parts[-2]
-        parent_col = parts[-1]
+        parent_table, parent_col = parse_referred_column(tc.referredColumns[0])
+        if parent_col is None:
+            continue  # no column component — cannot match against the parent PK
         fks.append((tc.columns[0], parent_table, parent_col))
     return fks
 

--- a/packages/ontology-engine/src/coa_ontology/inducer/strategies/base.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/strategies/base.py
@@ -5,9 +5,11 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import re
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 
 from coa_common import sql_ident
 from coa_common.bedrock_metrics import CostTracker
@@ -152,6 +154,76 @@ def to_camel(s: str) -> str:
     return p[0].lower() + p[1:] if p else p
 
 
+def _name_discriminator(name: str) -> str:
+    """Return a short deterministic suffix distinguishing ``name`` from its peers.
+
+    Derived from the verbatim name, so it is stable across runs (no hashing of
+    iteration order or object identity) and identical in every consumer that
+    mints IRIs for the same table.
+    """
+    return hashlib.sha256(name.encode("utf-8")).hexdigest()[:8]
+
+
+def pascal_names_for(names: Iterable[str]) -> dict[str, str]:
+    r"""Map each verbatim table name to a COLLISION-FREE PascalCase local name.
+
+    :func:`to_pascal` is lossy: it strips every character outside
+    ``[a-zA-Z0-9\s_\-]``, treats space/underscore/hyphen as one separator
+    class, and normalizes case. So ``order_item``, ``order-item``,
+    ``Order_Item``, and ``ORDER ITEM`` all collapse onto ``OrderItem``, and any
+    name made entirely of stripped characters collapses onto the ``"Entity"``
+    fallback. Minting class / TriplesMap IRIs straight from ``to_pascal`` therefore
+    silently FUSES distinct source tables onto one IRI: one class carrying both
+    tables' labels, key axioms, and cardinality restrictions, and — worse — one
+    TriplesMap carrying two ``rr:logicalTable`` / ``rr:tableName`` values, which
+    is invalid R2RML (a TriplesMap has exactly one logical table). Ontop then
+    either rejects the whole mapping (VKG load fails for the namespace) or picks
+    one table non-deterministically and drops the other's data.
+
+    This helper resolves collisions instead: the first name (in the caller's
+    order) keeps the bare PascalCase form so existing single-table-per-name
+    deployments mint byte-identical IRIs, and each subsequent colliding name gets
+    ``{Pascal}_{sha256(name)[:8]}`` appended. The discriminator is derived from
+    the verbatim name, so the assignment is deterministic given the same input
+    order and is reproducible across the ontology builder, the R2RML builder, and
+    the SHACL config generator — all three must agree or the artifacts diverge.
+
+    Callers should also surface a collision to the user (see the ``log.warning``
+    below): a silent merge is the worst of the possible outcomes, and a schema
+    that needs a discriminator usually indicates a naming problem worth fixing at
+    the source.
+
+    Args:
+        names: Verbatim table names, in a stable order.
+
+    Returns:
+        ``{verbatim_name: unique_pascal_local_name}`` covering every input name.
+    """
+    result: dict[str, str] = {}
+    taken: set[str] = set()
+    for name in names:
+        if name in result:
+            continue  # duplicate entry for the same table — one mapping is enough
+        base = to_pascal(name)
+        candidate = base
+        if candidate in taken:
+            candidate = f"{base}_{_name_discriminator(name)}"
+            log.warning(
+                "table_name_collides_after_pascal_case",
+                extra={"table": name, "collided_on": base, "minted": candidate},
+            )
+            # Pathological: the discriminated form is itself taken (two tables
+            # with the same verbatim name would have been deduped above, so this
+            # needs a genuine hash collision). Widen until unique.
+            suffix = 2
+            while candidate in taken:
+                candidate = f"{base}_{_name_discriminator(name)}_{suffix}"
+                suffix += 1
+        taken.add(candidate)
+        result[name] = candidate
+    return result
+
+
 def _annotate_triples_map(g: Graph, tmap: URIRef, table: CatalogTable) -> None:
     """Annotate a TriplesMap with datasource provenance (coa:datasourceId, coa:sourceSchema).
 
@@ -254,14 +326,22 @@ class InductionStrategy(ABC):
         g.bind("ind", ns)
         g.bind("xsd", XSD)
 
-        # Build a lookup from table name → TriplesMap URI for parentTriplesMap refs
+        # Build a lookup from table name → TriplesMap URI for parentTriplesMap refs.
+        # Local names come from the collision-resolving helper, not bare
+        # to_pascal: two tables differing only in separators/case would otherwise
+        # share one TriplesMap IRI and produce two rr:tableName values on it
+        # (invalid R2RML — see pascal_names_for).
+        pascal_by_name = pascal_names_for(t.name for t in tables)
+        # Property local names derive from the (possibly discriminated) class
+        # local name, so a disambiguated class carries disambiguated predicates.
+        camel_by_name = {n: p[0].lower() + p[1:] if p else p for n, p in pascal_by_name.items()}
         tmap_by_name: dict[str, URIRef] = {}
         for table in tables:
-            tmap_by_name[table.name] = ns[f"TriplesMap_{to_pascal(table.name)}"]
+            tmap_by_name[table.name] = ns[f"TriplesMap_{pascal_by_name[table.name]}"]
 
         for table in tables:
             tmap = tmap_by_name[table.name]
-            table_cls = ns[to_pascal(table.name)]
+            table_cls = ns[pascal_by_name[table.name]]
 
             g.add((tmap, RDF.type, RR.TriplesMap))
             _annotate_triples_map(g, tmap, table)
@@ -311,7 +391,7 @@ class InductionStrategy(ABC):
                 pom = URIRef(f"{tmap}/POM_{to_pascal(col.name)}")
                 g.add((tmap, RR.predicateObjectMap, pom))
 
-                prop_uri = ns[f"{to_camel(table.name)}_{to_camel(col.name)}"]
+                prop_uri = ns[f"{camel_by_name[table.name]}_{to_camel(col.name)}"]
                 g.add((pom, RR.predicate, prop_uri))
 
                 om = URIRef(f"{pom}/ObjectMap")
@@ -363,6 +443,10 @@ class InductionStrategy(ABC):
                     fk_target = composite_fk.referredColumns[0].split(".")[0]
                     parent_tmap = tmap_by_name.get(fk_target)
                     if parent_tmap is None:
+                        # Target table is outside this induction run, so it has no
+                        # entry in pascal_by_name. Fall back to the bare form —
+                        # nothing to collide with here, since a table we did not
+                        # process has no TriplesMap in this mapping either.
                         parent_tmap = ns[f"TriplesMap_{to_pascal(fk_target)}"]
 
                     g.add((om, RR.parentTriplesMap, parent_tmap))

--- a/packages/ontology-engine/src/coa_ontology/inducer/strategies/base.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/strategies/base.py
@@ -224,6 +224,81 @@ def pascal_names_for(names: Iterable[str]) -> dict[str, str]:
     return result
 
 
+def composite_fk_is_usable(tc) -> bool:
+    """True when a composite FK constraint can produce a valid Referencing Object Map.
+
+    :meth:`InductionStrategy.build_r2rml` degrades a composite FK to plain datatype
+    ObjectMaps when it is malformed — ``columns`` / ``referredColumns`` of unequal
+    length (no way to pair them into join conditions), or ``referredColumns``
+    spanning several target tables (a TriplesMap has one parent). The ontology
+    builder must apply the SAME test, or it declares an ``owl:ObjectProperty`` with
+    ``rdfs:range <ParentClass>`` for a column the mapping exposes as a string or
+    integer literal: ``rdfs:range`` and ``rr:datatype`` then disagree, and Ontop's
+    type reasoning drops the triples or fails the SPARQL type filter.
+    """
+    if tc.constraintType != "FOREIGN_KEY" or not tc.referredColumns or len(tc.columns or []) <= 1:
+        return False
+    if len(tc.columns) != len(tc.referredColumns):
+        return False
+    fk_tables = {rc.split(".")[0] for rc in tc.referredColumns if "." in rc}
+    return len(fk_tables) <= 1
+
+
+def composite_fk_columns(table: CatalogTable) -> dict[str, str]:
+    """Map each column absorbed into a composite-FK POM to the column that owns it.
+
+    A composite (multi-column) FK is expressed in R2RML as ONE Referencing Object
+    Map carrying one ``rr:joinCondition`` per column pair (§7.5) — not one map per
+    column. :meth:`InductionStrategy.build_r2rml` therefore emits a single POM,
+    anchored on the constraint's FIRST column, and emits nothing for the rest.
+
+    The ontology builder must know which columns those are. Declaring an
+    ``owl:ObjectProperty`` per participating column (the obvious reading of the
+    constraint) mints properties that have no POM behind them: they appear in the
+    published TBox, in the class/property browser, and in the TBox context handed
+    to the NL→SPARQL LLM, so the model is actively encouraged to author SPARQL
+    against a property Ontop cannot resolve to any column. The query compiles and
+    returns nothing, with no mapping-gap signal in the logs. The gap scales with
+    arity: a 3-column FK orphaned 2 properties.
+
+    A MALFORMED composite FK (see :func:`composite_fk_is_usable`) behaves
+    differently: ``build_r2rml`` gives every one of its columns a datatype
+    ObjectMap, so none is absorbed — but none carries the relationship either, and
+    the ontology must not declare any of them an object property. Those columns map
+    to ``""``, letting the caller distinguish "absorbed into a sibling's POM" from
+    "no relationship at all" while treating both as non-object properties.
+
+    Returns:
+        ``{column: owning_column}`` for columns absorbed into a sibling's POM, plus
+        ``{column: ""}`` for every column of a malformed composite FK. The owning
+        (first) column of a USABLE composite FK is absent — it keeps both its POM
+        and its object property. Empty when the table has no composite FK.
+    """
+    absorbed: dict[str, str] = {}
+    if not table.tableConstraints:
+        return absorbed
+    table_columns = {c.name for c in table.columns}
+    for tc in table.tableConstraints:
+        if tc.constraintType != "FOREIGN_KEY" or not tc.referredColumns or len(tc.columns or []) <= 1:
+            continue
+        if not composite_fk_is_usable(tc):
+            # Degraded to datatype ObjectMaps in the mapping — no object property
+            # for ANY of these columns, the first one included.
+            for col_name in tc.columns:
+                if col_name in table_columns:
+                    absorbed.setdefault(col_name, "")
+            continue
+        # build_r2rml anchors the POM on the first column of the constraint that
+        # the table actually has (it iterates table.columns), so mirror that.
+        owner = next((c for c in table.columns if c.name in tc.columns), None)
+        if owner is None:
+            continue
+        for col_name in tc.columns:
+            if col_name != owner.name and col_name in table_columns:
+                absorbed.setdefault(col_name, owner.name)
+    return absorbed
+
+
 def _annotate_triples_map(g: Graph, tmap: URIRef, table: CatalogTable) -> None:
     """Annotate a TriplesMap with datasource provenance (coa:datasourceId, coa:sourceSchema).
 
@@ -379,13 +454,30 @@ class InductionStrategy(ABC):
                     if tc.constraintType == "FOREIGN_KEY" and tc.referredColumns and len(tc.columns) > 1:
                         composite_fk_constraints.append(tc)
 
-            # Track which columns have already been emitted as part of a composite FK
-            # to avoid emitting duplicate POMs.
-            composite_fk_emitted: set[str] = set()
+            # Columns a USABLE composite FK folds into its owning column's
+            # referencing map. Computed up front (not accumulated while iterating)
+            # so the branch below is independent of column order, and shared with
+            # the ontology builder so both agree on which columns are literals.
+            absorbed_columns = {name for name, owner in composite_fk_columns(table).items() if owner}
 
             for col in table.columns:
-                # Skip columns already emitted as part of a composite FK POM
-                if col.name in composite_fk_emitted:
+                # A column absorbed into a sibling's composite-FK Referencing
+                # Object Map still gets its OWN datatype POM. The relationship is
+                # carried once (by the owning column's referencing map, per R2RML
+                # §7.5) — but the column is a real column, and leaving it unmapped
+                # meant the ontology's declaration for it had nothing behind it, so
+                # any SPARQL touching that property silently returned nothing.
+                # Emitting a literal mapping keeps mapping and ontology in step:
+                # the ontology declares these columns as datatype properties (see
+                # composite_fk_columns).
+                if col.name in absorbed_columns:
+                    pom = URIRef(f"{tmap}/POM_{to_pascal(col.name)}")
+                    g.add((tmap, RR.predicateObjectMap, pom))
+                    g.add((pom, RR.predicate, ns[f"{camel_by_name[table.name]}_{to_camel(col.name)}"]))
+                    om = URIRef(f"{pom}/ObjectMap")
+                    g.add((pom, RR.objectMap, om))
+                    g.add((om, RR.column, Literal(sql_ident(col.name))))
+                    g.add((om, RR.datatype, xsd_for_column(col.dataType, col.name)))
                     continue
 
                 pom = URIRef(f"{tmap}/POM_{to_pascal(col.name)}")
@@ -416,8 +508,6 @@ class InductionStrategy(ABC):
                             len(composite_fk.columns),
                             len(composite_fk.referredColumns),
                         )
-                        for c in composite_fk.columns:
-                            composite_fk_emitted.add(c)
                         composite_fk_constraints.remove(composite_fk)
                         g.add((om, RR.column, Literal(sql_ident(col.name))))
                         dt = xsd_for(col.dataType)
@@ -432,8 +522,6 @@ class InductionStrategy(ABC):
                             table.name,
                             fk_tables,
                         )
-                        for c in composite_fk.columns:
-                            composite_fk_emitted.add(c)
                         composite_fk_constraints.remove(composite_fk)
                         g.add((om, RR.column, Literal(sql_ident(col.name))))
                         dt = xsd_for(col.dataType)
@@ -458,9 +546,6 @@ class InductionStrategy(ABC):
                         g.add((jc, RR.child, Literal(sql_ident(child_col))))
                         g.add((jc, RR.parent, Literal(sql_ident(parent_col))))
 
-                    # Mark all columns in this composite FK as emitted
-                    for c in composite_fk.columns:
-                        composite_fk_emitted.add(c)
                     # Remove from composite list to avoid re-processing
                     composite_fk_constraints.remove(composite_fk)
                     continue

--- a/packages/ontology-engine/src/coa_ontology/inducer/strategies/base.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/strategies/base.py
@@ -158,25 +158,43 @@ def to_camel(s: str) -> str:
     return p[0].lower() + p[1:] if p else p
 
 
-def _name_discriminator(name: str) -> str:
-    """Return a short deterministic suffix distinguishing ``name`` from its peers.
+def _name_discriminator(identity: str) -> str:
+    """Return a short deterministic suffix distinguishing ``identity`` from its peers.
 
-    Derived from the verbatim name, so it is stable across runs (no hashing of
-    iteration order or object identity) and identical in every consumer that
-    mints IRIs for the same table.
+    Derived from the table's verbatim identity (see :func:`table_identity`), so it
+    is stable across runs (no hashing of iteration order or object identity) and
+    identical in every consumer that mints IRIs for the same table.
     """
-    return hashlib.sha256(name.encode("utf-8")).hexdigest()[:8]
+    return hashlib.sha256(identity.encode("utf-8")).hexdigest()[:8]
 
 
-def pascal_names_for(names: Iterable[str]) -> dict[str, str]:
-    r"""Map each verbatim table name to a COLLISION-FREE PascalCase local name.
+def table_identity(table: CatalogTable) -> str:
+    """Return the key that distinguishes ``table`` from every other table in a run.
+
+    ``CatalogTable.name`` is the BARE table name: ``_catalog_to_tables`` fills it
+    from ``tbl["name"]`` and puts the qualified form in ``fullyQualifiedName``. A
+    single induction flattens every database of every requested datasource into one
+    list, so bare names repeat routinely — ``public.customers`` and
+    ``analytics.customers`` are two tables that must stay two classes, two
+    TriplesMaps, and two sets of properties. Keying anything on ``name`` fuses them.
+
+    The qualified name is the identity; the bare name still supplies the *display*
+    form the PascalCase local name is derived from, so a table whose name is unique
+    mints exactly the IRI it minted before.
+    """
+    return table.fullyQualifiedName or table.name
+
+
+def pascal_names_for(tables: Iterable[CatalogTable]) -> dict[str, str]:
+    r"""Map each table IDENTITY to a COLLISION-FREE PascalCase local name.
 
     :func:`to_pascal` is lossy: it strips every character outside
     ``[a-zA-Z0-9\s_\-]``, treats space/underscore/hyphen as one separator
     class, and normalizes case. So ``order_item``, ``order-item``,
     ``Order_Item``, and ``ORDER ITEM`` all collapse onto ``OrderItem``, and any
     name made entirely of stripped characters collapses onto the ``"Entity"``
-    fallback. Minting class / TriplesMap IRIs straight from ``to_pascal`` therefore
+    fallback. Two tables in different databases can also share a bare name
+    outright. Minting class / TriplesMap IRIs straight from ``to_pascal`` therefore
     silently FUSES distinct source tables onto one IRI: one class carrying both
     tables' labels, key axioms, and cardinality restrictions, and — worse — one
     TriplesMap carrying two ``rr:logicalTable`` / ``rr:tableName`` values, which
@@ -184,12 +202,22 @@ def pascal_names_for(names: Iterable[str]) -> dict[str, str]:
     either rejects the whole mapping (VKG load fails for the namespace) or picks
     one table non-deterministically and drops the other's data.
 
-    This helper resolves collisions instead: the first name (in the caller's
-    order) keeps the bare PascalCase form so existing single-table-per-name
-    deployments mint byte-identical IRIs, and each subsequent colliding name gets
-    ``{Pascal}_{sha256(name)[:8]}`` appended. The discriminator is derived from
-    the verbatim name, so the assignment is deterministic given the same input
-    order and is reproducible across the ontology builder, the R2RML builder, and
+    This helper resolves collisions instead. Within a colliding set, ONE identity
+    keeps the bare PascalCase form so existing single-table-per-name deployments
+    mint byte-identical IRIs, and the others get ``{Pascal}_{sha256(identity)[:8]}``
+    appended.
+
+    Which one keeps the bare form is decided by ``min()`` over the identities, NOT
+    by input order. Order would be the more obvious rule and is wrong here: the
+    caller's list comes from ``_catalog_to_tables``, which flattens catalogs in
+    whatever order Glue / OMD enumerated them and never sorts. Under an
+    order-dependent rule, re-inducing the same schema after an enumeration change
+    moves the bare name to a different table, so the IRIs in a newly generated
+    mapping stop matching the ones in an already-accepted ontology — the exact
+    divergence this helper exists to prevent. Keying on the identity instead makes
+    the assignment a pure function of the schema.
+
+    The result is reproducible across the ontology builder, the R2RML builder, and
     the SHACL config generator — all three must agree or the artifacts diverge.
 
     Callers should also surface a collision to the user (see the ``log.warning``
@@ -198,34 +226,94 @@ def pascal_names_for(names: Iterable[str]) -> dict[str, str]:
     the source.
 
     Args:
-        names: Verbatim table names, in a stable order.
+        tables: Tables in the induction run. Duplicate identities are collapsed.
 
     Returns:
-        ``{verbatim_name: unique_pascal_local_name}`` covering every input name.
+        ``{table_identity: unique_pascal_local_name}`` covering every input table,
+        keyed by :func:`table_identity` — NOT by ``table.name``.
     """
-    result: dict[str, str] = {}
-    taken: set[str] = set()
-    for name in names:
-        if name in result:
+    identities: list[str] = []
+    display_base: dict[str, str] = {}
+    for table in tables:
+        identity = table_identity(table)
+        if identity in display_base:
             continue  # duplicate entry for the same table — one mapping is enough
-        base = to_pascal(name)
-        candidate = base
-        if candidate in taken:
-            candidate = f"{base}_{_name_discriminator(name)}"
+        identities.append(identity)
+        display_base[identity] = to_pascal(table.name)
+
+    by_base: dict[str, list[str]] = {}
+    for identity in identities:
+        by_base.setdefault(display_base[identity], []).append(identity)
+
+    assigned: dict[str, str] = {}
+    taken: set[str] = set()
+    # Sorted so that a residual collision between one base and another base's
+    # discriminated form resolves the same way on every run.
+    for base in sorted(by_base):
+        members = by_base[base]
+        keeper = min(members)
+        for identity in sorted(members):
+            candidate = base if identity == keeper else f"{base}_{_name_discriminator(identity)}"
+            if identity != keeper:
+                log.warning(
+                    "table_name_collides_after_pascal_case",
+                    extra={"table": identity, "collided_on": base, "minted": candidate},
+                )
+            if candidate in taken:
+                # Pathological: the form is already taken (identities were deduped
+                # above, so this needs a genuine hash collision, or a base equal to
+                # another base's discriminated form). Widen until unique.
+                candidate = f"{base}_{_name_discriminator(identity)}"
+                suffix = 2
+                while candidate in taken:
+                    candidate = f"{base}_{_name_discriminator(identity)}_{suffix}"
+                    suffix += 1
+            taken.add(candidate)
+            assigned[identity] = candidate
+    # Returned in caller order: the assignment does not depend on it, but stable
+    # iteration keeps logs and serialized artifacts diff-friendly.
+    return {identity: assigned[identity] for identity in identities}
+
+
+def reference_index(tables: Iterable[CatalogTable]) -> dict[str, str]:
+    """Map the forms an FK target can be written in to a table identity.
+
+    ``referredColumns`` names its target table WITHOUT a database qualifier —
+    :func:`parse_referred_column` yields ``(table, column)`` — so resolving a
+    parent requires a lookup keyed on the bare name. That is ambiguous the moment
+    two databases in the run contain the same table name, which is exactly the case
+    :func:`table_identity` exists for.
+
+    Keys, in the order callers should try them:
+
+    - ``"{sourceSchema}.{name}"`` — prefer the referrer's own database. An FK
+      almost never crosses databases, so this is the reading that matches the SQL
+      the mapping will be compiled into.
+    - ``"{name}"`` — only when that bare name is unambiguous across the whole run.
+      An ambiguous bare name is deliberately ABSENT so the caller falls back to its
+      out-of-run behaviour rather than picking a parent at random; a wrong
+      ``rr:parentTriplesMap`` joins real data to the wrong table, which is worse
+      than an unresolved reference.
+    - the identity itself, so an already-qualified reference resolves too.
+    """
+    index: dict[str, str] = {}
+    by_name: dict[str, list[str]] = {}
+    for table in tables:
+        identity = table_identity(table)
+        index[identity] = identity
+        if table.sourceSchema:
+            index[f"{table.sourceSchema}.{table.name}"] = identity
+        if identity not in by_name.get(table.name, []):
+            by_name.setdefault(table.name, []).append(identity)
+    for name, identities in by_name.items():
+        if len(identities) == 1:
+            index.setdefault(name, identities[0])
+        else:
             log.warning(
-                "table_name_collides_after_pascal_case",
-                extra={"table": name, "collided_on": base, "minted": candidate},
+                "fk_target_table_name_is_ambiguous",
+                extra={"table": name, "candidates": sorted(identities)},
             )
-            # Pathological: the discriminated form is itself taken (two tables
-            # with the same verbatim name would have been deduped above, so this
-            # needs a genuine hash collision). Widen until unique.
-            suffix = 2
-            while candidate in taken:
-                candidate = f"{base}_{_name_discriminator(name)}_{suffix}"
-                suffix += 1
-        taken.add(candidate)
-        result[name] = candidate
-    return result
+    return index
 
 
 def composite_fk_is_usable(tc: CatalogConstraint) -> bool:
@@ -317,9 +405,12 @@ def composite_fk_columns(table: CatalogTable) -> dict[str, str]:
         for col_name in tc.columns:
             if col_name != owner and col_name in table_columns:
                 absorbed.setdefault(col_name, owner)
-    # An anchor is never absorbed: it carries its own relationship. This can only
-    # bite when constraints overlap — `composite_fk_anchors` skips folded columns,
-    # so a column it chose as an anchor was not folded in by an earlier one.
+    # An anchor is never absorbed: it carries its own relationship. This also
+    # overrides the malformed pass above, which may have marked the column as
+    # relationship-free because a DIFFERENT, broken constraint lists it —
+    # ``build_r2rml`` checks the anchor before the malformed degradation for the
+    # same reason, and the two must agree or the ontology declares an
+    # ``owl:ObjectProperty`` against an ``rr:datatype`` literal.
     for anchor in anchors:
         absorbed.pop(anchor, None)
     return absorbed
@@ -471,22 +562,42 @@ class InductionStrategy(ABC):
         g.bind("ind", ns)
         g.bind("xsd", XSD)
 
-        # Build a lookup from table name → TriplesMap URI for parentTriplesMap refs.
-        # Local names come from the collision-resolving helper, not bare
-        # to_pascal: two tables differing only in separators/case would otherwise
-        # share one TriplesMap IRI and produce two rr:tableName values on it
-        # (invalid R2RML — see pascal_names_for).
-        pascal_by_name = pascal_names_for(t.name for t in tables)
+        # Build a lookup from table identity → TriplesMap URI for parentTriplesMap
+        # refs. Local names come from the collision-resolving helper, not bare
+        # to_pascal: two tables differing only in separators/case — or two tables
+        # with the same bare name in different databases — would otherwise share
+        # one TriplesMap IRI and produce two rr:tableName values on it (invalid
+        # R2RML — see pascal_names_for). The key is the IDENTITY, not the name:
+        # keying on the name is what let same-named tables collapse.
+        pascal_by_id = pascal_names_for(tables)
         # Property local names derive from the (possibly discriminated) class
         # local name, so a disambiguated class carries disambiguated predicates.
-        camel_by_name = {n: p[0].lower() + p[1:] if p else p for n, p in pascal_by_name.items()}
-        tmap_by_name: dict[str, URIRef] = {}
+        camel_by_id = {i: p[0].lower() + p[1:] if p else p for i, p in pascal_by_id.items()}
+        # How an FK's bare target name resolves to an identity (schema-qualified
+        # first, then bare when unambiguous).
+        ref_index = reference_index(tables)
+        tmap_by_id: dict[str, URIRef] = {}
         for table in tables:
-            tmap_by_name[table.name] = ns[f"TriplesMap_{pascal_by_name[table.name]}"]
+            identity = table_identity(table)
+            tmap_by_id[identity] = ns[f"TriplesMap_{pascal_by_id[identity]}"]
+
+        def _parent_tmap(target_name: str, referrer: CatalogTable) -> URIRef:
+            """Resolve an FK target table name to its TriplesMap IRI."""
+            qualified = f"{referrer.sourceSchema}.{target_name}" if referrer.sourceSchema else None
+            target_id = (qualified and ref_index.get(qualified)) or ref_index.get(target_name)
+            if target_id is not None and target_id in tmap_by_id:
+                return tmap_by_id[target_id]
+            # Target table is outside this induction run (or its bare name is
+            # ambiguous, in which case guessing a parent would join real data to
+            # the wrong table). Fall back to the bare form — nothing to collide
+            # with here, since a table we did not process has no TriplesMap in
+            # this mapping either.
+            return ns[f"TriplesMap_{to_pascal(target_name)}"]
 
         for table in tables:
-            tmap = tmap_by_name[table.name]
-            table_cls = ns[pascal_by_name[table.name]]
+            identity = table_identity(table)
+            tmap = tmap_by_id[identity]
+            table_cls = ns[pascal_by_id[identity]]
 
             g.add((tmap, RDF.type, RR.TriplesMap))
             _annotate_triples_map(g, tmap, table)
@@ -551,7 +662,7 @@ class InductionStrategy(ABC):
                 if col.name in absorbed_columns:
                     pom = URIRef(f"{tmap}/POM_{to_pascal(col.name)}")
                     g.add((tmap, RR.predicateObjectMap, pom))
-                    g.add((pom, RR.predicate, ns[f"{camel_by_name[table.name]}_{to_camel(col.name)}"]))
+                    g.add((pom, RR.predicate, ns[f"{camel_by_id[identity]}_{to_camel(col.name)}"]))
                     om = URIRef(f"{pom}/ObjectMap")
                     g.add((pom, RR.objectMap, om))
                     g.add((om, RR.column, Literal(sql_ident(col.name))))
@@ -561,7 +672,7 @@ class InductionStrategy(ABC):
                 pom = URIRef(f"{tmap}/POM_{to_pascal(col.name)}")
                 g.add((tmap, RR.predicateObjectMap, pom))
 
-                prop_uri = ns[f"{camel_by_name[table.name]}_{to_camel(col.name)}"]
+                prop_uri = ns[f"{camel_by_id[identity]}_{to_camel(col.name)}"]
                 g.add((pom, RR.predicate, prop_uri))
 
                 om = URIRef(f"{pom}/ObjectMap")
@@ -570,6 +681,34 @@ class InductionStrategy(ABC):
                 # This column anchors a composite FK when the shared anchor table
                 # says so — never by re-deriving it here.
                 composite_fk = composite_anchors.get(col.name)
+
+                if composite_fk is not None and composite_fk.referredColumns:
+                    # Composite FK: emit a single Referencing Object Map for the
+                    # entire relationship, with one joinCondition per column pair.
+                    #
+                    # Checked BEFORE the malformed branch below, and the order is
+                    # load-bearing. A column can sit in a malformed constraint AND
+                    # anchor a well-formed one; degrading it to a literal because
+                    # some OTHER constraint mentioning it is broken threw away a
+                    # relationship that is perfectly expressible, and left the
+                    # ontology (which asks composite_fk_anchors, and so still
+                    # declared an owl:ObjectProperty with rdfs:range) contradicting
+                    # this mapping's rr:datatype — the very mismatch the composite-FK
+                    # fix set out to remove.
+                    fk_target, _ = parse_referred_column(composite_fk.referredColumns[0])
+                    g.add((om, RR.parentTriplesMap, _parent_tmap(fk_target, table)))
+                    for child_col, ref_col in zip(composite_fk.columns, composite_fk.referredColumns, strict=True):
+                        _, parsed_parent = parse_referred_column(ref_col)
+                        parent_col = parsed_parent if parsed_parent is not None else ref_col
+                        jc = BNode()
+                        g.add((om, RR.joinCondition, jc))
+                        g.add((jc, RR.child, Literal(sql_ident(child_col))))
+                        g.add((jc, RR.parent, Literal(sql_ident(parent_col))))
+
+                    # No bookkeeping needed: composite_fk_anchors already assigned
+                    # each constraint to exactly one column, so no other column can
+                    # re-emit this relationship.
+                    continue
 
                 if col.name in malformed_composite_columns:
                     # columns/referredColumns disagree in length, or the targets span
@@ -584,32 +723,6 @@ class InductionStrategy(ABC):
                     )
                     g.add((om, RR.column, Literal(sql_ident(col.name))))
                     g.add((om, RR.datatype, xsd_for_column(col.dataType, col.name)))
-                    continue
-
-                if composite_fk is not None and composite_fk.referredColumns:
-                    # Composite FK: emit a single Referencing Object Map for the
-                    # entire relationship, with one joinCondition per column pair.
-                    fk_target, _ = parse_referred_column(composite_fk.referredColumns[0])
-                    parent_tmap = tmap_by_name.get(fk_target)
-                    if parent_tmap is None:
-                        # Target table is outside this induction run, so it has no
-                        # entry in pascal_by_name. Fall back to the bare form —
-                        # nothing to collide with here, since a table we did not
-                        # process has no TriplesMap in this mapping either.
-                        parent_tmap = ns[f"TriplesMap_{to_pascal(fk_target)}"]
-
-                    g.add((om, RR.parentTriplesMap, parent_tmap))
-                    for child_col, ref_col in zip(composite_fk.columns, composite_fk.referredColumns, strict=True):
-                        _, parsed_parent = parse_referred_column(ref_col)
-                        parent_col = parsed_parent if parsed_parent is not None else ref_col
-                        jc = BNode()
-                        g.add((om, RR.joinCondition, jc))
-                        g.add((jc, RR.child, Literal(sql_ident(child_col))))
-                        g.add((jc, RR.parent, Literal(sql_ident(parent_col))))
-
-                    # No bookkeeping needed: composite_fk_anchors already assigned
-                    # each constraint to exactly one column, so no other column can
-                    # re-emit this relationship.
                     continue
 
                 # Check for simple (single-column) FK
@@ -633,9 +746,7 @@ class InductionStrategy(ABC):
                     # fk_parent_col is required — without it we cannot emit a valid
                     # joinCondition and a bare parentTriplesMap would produce a
                     # Cartesian product in Ontop (R2RML §7.5).
-                    parent_tmap = tmap_by_name.get(simple_fk_target)
-                    if parent_tmap is None:
-                        parent_tmap = ns[f"TriplesMap_{to_pascal(simple_fk_target)}"]
+                    parent_tmap = _parent_tmap(simple_fk_target, table)
 
                     g.add((om, RR.parentTriplesMap, parent_tmap))
                     jc = BNode()

--- a/packages/ontology-engine/src/coa_ontology/inducer/strategies/base.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/strategies/base.py
@@ -17,7 +17,7 @@ from coa_common.constants import VOCAB_URI
 from rdflib import RDF, XSD, BNode, Graph, Literal, Namespace, URIRef
 
 from coa_ontology.inducer.schemas import ConceptMatch
-from coa_ontology.inducer.services.data_catalog import CatalogTable
+from coa_ontology.inducer.services.data_catalog import CatalogTable, parse_referred_column
 
 log = logging.getLogger(__name__)
 
@@ -240,7 +240,7 @@ def composite_fk_is_usable(tc) -> bool:
         return False
     if len(tc.columns) != len(tc.referredColumns):
         return False
-    fk_tables = {rc.split(".")[0] for rc in tc.referredColumns if "." in rc}
+    fk_tables = {parse_referred_column(rc)[0] for rc in tc.referredColumns if "." in rc}
     return len(fk_tables) <= 1
 
 
@@ -515,7 +515,7 @@ class InductionStrategy(ABC):
                         continue
 
                     # Validate: all referredColumns must reference the same target table.
-                    fk_tables = {rc.split(".")[0] for rc in composite_fk.referredColumns if "." in rc}
+                    fk_tables = {parse_referred_column(rc)[0] for rc in composite_fk.referredColumns if "." in rc}
                     if len(fk_tables) > 1:
                         log.warning(
                             "Skipping composite FK on %s: referredColumns span multiple tables %s",
@@ -528,7 +528,7 @@ class InductionStrategy(ABC):
                         g.add((om, RR.datatype, dt))
                         continue
 
-                    fk_target = composite_fk.referredColumns[0].split(".")[0]
+                    fk_target, _ = parse_referred_column(composite_fk.referredColumns[0])
                     parent_tmap = tmap_by_name.get(fk_target)
                     if parent_tmap is None:
                         # Target table is outside this induction run, so it has no
@@ -539,8 +539,8 @@ class InductionStrategy(ABC):
 
                     g.add((om, RR.parentTriplesMap, parent_tmap))
                     for child_col, ref_col in zip(composite_fk.columns, composite_fk.referredColumns, strict=True):
-                        parts = ref_col.split(".")
-                        parent_col = parts[-1] if len(parts) >= 2 else parts[0]
+                        _, parsed_parent = parse_referred_column(ref_col)
+                        parent_col = parsed_parent if parsed_parent is not None else ref_col
                         jc = BNode()
                         g.add((om, RR.joinCondition, jc))
                         g.add((jc, RR.child, Literal(sql_ident(child_col))))
@@ -563,9 +563,7 @@ class InductionStrategy(ABC):
                             and tc.referredColumns
                         ):
                             is_fk = True
-                            parts = tc.referredColumns[0].split(".")
-                            simple_fk_target = parts[0]
-                            fk_parent_col = parts[-1] if len(parts) >= 2 else None
+                            simple_fk_target, fk_parent_col = parse_referred_column(tc.referredColumns[0])
                             break
 
                 if is_fk and simple_fk_target and fk_parent_col:

--- a/packages/ontology-engine/src/coa_ontology/inducer/strategies/base.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/strategies/base.py
@@ -17,7 +17,11 @@ from coa_common.constants import VOCAB_URI
 from rdflib import RDF, XSD, BNode, Graph, Literal, Namespace, URIRef
 
 from coa_ontology.inducer.schemas import ConceptMatch
-from coa_ontology.inducer.services.data_catalog import CatalogTable, parse_referred_column
+from coa_ontology.inducer.services.data_catalog import (
+    CatalogConstraint,
+    CatalogTable,
+    parse_referred_column,
+)
 
 log = logging.getLogger(__name__)
 
@@ -224,7 +228,7 @@ def pascal_names_for(names: Iterable[str]) -> dict[str, str]:
     return result
 
 
-def composite_fk_is_usable(tc) -> bool:
+def composite_fk_is_usable(tc: CatalogConstraint) -> bool:
     """True when a composite FK constraint can produce a valid Referencing Object Map.
 
     :meth:`InductionStrategy.build_r2rml` degrades a composite FK to plain datatype
@@ -273,30 +277,96 @@ def composite_fk_columns(table: CatalogTable) -> dict[str, str]:
         ``{column: ""}`` for every column of a malformed composite FK. The owning
         (first) column of a USABLE composite FK is absent — it keeps both its POM
         and its object property. Empty when the table has no composite FK.
+
+    Mirrors :meth:`InductionStrategy.build_r2rml`'s CONSUMING walk exactly, which
+    matters when two composite FKs share a column. For ``FK1 = (a, b) -> p1`` and
+    ``FK2 = (b, c) -> p2``, walking the columns in order assigns ``a`` to FK1
+    (absorbing ``b``), and then ``c`` — reached with FK1 already consumed — anchors
+    FK2. A non-consuming implementation instead matched ``c`` against FK2 while
+    treating it as absorbed by ``b``, which silently dropped the child→p2
+    relationship from BOTH artifacts. So the walk order and the removal are
+    load-bearing, not incidental.
     """
     absorbed: dict[str, str] = {}
     if not table.tableConstraints:
         return absorbed
     table_columns = {c.name for c in table.columns}
+
+    # Malformed composite FKs first: build_r2rml degrades every one of their
+    # columns to a literal regardless of position, so they never anchor anything.
+    remaining = []
     for tc in table.tableConstraints:
         if tc.constraintType != "FOREIGN_KEY" or not tc.referredColumns or len(tc.columns or []) <= 1:
             continue
-        if not composite_fk_is_usable(tc):
-            # Degraded to datatype ObjectMaps in the mapping — no object property
-            # for ANY of these columns, the first one included.
+        if composite_fk_is_usable(tc):
+            remaining.append(tc)
+        else:
             for col_name in tc.columns:
                 if col_name in table_columns:
                     absorbed.setdefault(col_name, "")
-            continue
-        # build_r2rml anchors the POM on the first column of the constraint that
-        # the table actually has (it iterates table.columns), so mirror that.
-        owner = next((c for c in table.columns if c.name in tc.columns), None)
-        if owner is None:
-            continue
+
+    # Then replay build_r2rml's walk: for each column in order, claim the first
+    # not-yet-claimed constraint it participates in. That column becomes the
+    # anchor, and the constraint is consumed so a later column cannot claim it
+    # again. Anchors are recorded as they are decided; absorbed columns are
+    # resolved afterwards, because a column can be a LATER constraint's anchor
+    # even though an earlier constraint also lists it — with (a,b)->p1,
+    # (b,c)->p2, (c,d)->p3, `c` anchors FK2 and must not be absorbed by FK3.
+    anchors = composite_fk_anchors(table)
+    for owner, tc in anchors.items():
         for col_name in tc.columns:
-            if col_name != owner.name and col_name in table_columns:
-                absorbed.setdefault(col_name, owner.name)
+            if col_name != owner and col_name in table_columns:
+                absorbed.setdefault(col_name, owner)
+    # An anchor is never absorbed: it carries its own relationship. This can only
+    # bite when constraints overlap — `composite_fk_anchors` skips folded columns,
+    # so a column it chose as an anchor was not folded in by an earlier one.
+    for anchor in anchors:
+        absorbed.pop(anchor, None)
     return absorbed
+
+
+def composite_fk_anchors(table: CatalogTable) -> dict[str, CatalogConstraint]:
+    """Map each column that ANCHORS a usable composite FK to that constraint.
+
+    Single source of truth for the anchor assignment, consumed by both
+    :meth:`InductionStrategy.build_r2rml` (which emits one Referencing Object Map
+    per anchor) and :func:`composite_fk_columns` (which derives the absorbed
+    columns from it). Splitting the two apart is what let them disagree: the
+    mapping walked and CONSUMED constraints column by column while the ontology
+    side computed absorption independently, so for two FKs sharing a column they
+    picked different anchors and the relationship landed on different properties
+    in each artifact.
+
+    The rule reproduces the mapping's original walk exactly: visit columns in table
+    order; SKIP a column already folded into an earlier anchor's map; otherwise let
+    it claim the first unclaimed constraint it participates in, and consume that
+    constraint. Both the skip and the consumption matter. For (a,b)->p1 and
+    (b,c)->p2: `a` claims p1 and folds in `b`; `b` is skipped BECAUSE it is folded
+    in, so p2 falls to `c`. Dropping the skip hands p2 to `b` instead, which moves
+    the relationship onto a different property than the original mapping used.
+    """
+    anchors: dict[str, CatalogConstraint] = {}
+    if not table.tableConstraints:
+        return anchors
+    remaining = [
+        tc
+        for tc in table.tableConstraints
+        if tc.constraintType == "FOREIGN_KEY"
+        and tc.referredColumns
+        and len(tc.columns or []) > 1
+        and composite_fk_is_usable(tc)
+    ]
+    folded: set[str] = set()
+    for col in table.columns:
+        if col.name in folded:
+            continue
+        claimed = next((tc for tc in remaining if col.name in tc.columns), None)
+        if claimed is None:
+            continue
+        anchors[col.name] = claimed
+        remaining.remove(claimed)
+        folded.update(c for c in claimed.columns if c != col.name)
+    return anchors
 
 
 def _annotate_triples_map(g: Graph, tmap: URIRef, table: CatalogTable) -> None:
@@ -446,19 +516,27 @@ class InductionStrategy(ABC):
             g.add((subj, RR.template, Literal(template)))
             g.add((subj, RR["class"], table_cls))
 
-            # Pre-collect composite FK constraints so we can detect when a column
-            # participates in a multi-column FK (needs special handling).
-            composite_fk_constraints = []
-            if table.tableConstraints:
-                for tc in table.tableConstraints:
-                    if tc.constraintType == "FOREIGN_KEY" and tc.referredColumns and len(tc.columns) > 1:
-                        composite_fk_constraints.append(tc)
-
-            # Columns a USABLE composite FK folds into its owning column's
-            # referencing map. Computed up front (not accumulated while iterating)
-            # so the branch below is independent of column order, and shared with
-            # the ontology builder so both agree on which columns are literals.
+            # Which column carries which composite FK, and which columns it folds
+            # in. Both come from the SAME helpers the ontology builder uses, so the
+            # two artifacts cannot disagree about where a relationship lives — they
+            # previously derived it independently (a consuming walk here, a separate
+            # computation there) and picked different anchors for FKs sharing a
+            # column.
+            composite_anchors = composite_fk_anchors(table)
             absorbed_columns = {name for name, owner in composite_fk_columns(table).items() if owner}
+
+            # Malformed composite FKs never anchor anything (see
+            # composite_fk_is_usable); their columns fall through to the datatype
+            # path below, which is what build_r2rml has always done.
+            malformed_composite_columns = {
+                col_name
+                for tc in (table.tableConstraints or [])
+                if tc.constraintType == "FOREIGN_KEY"
+                and tc.referredColumns
+                and len(tc.columns or []) > 1
+                and not composite_fk_is_usable(tc)
+                for col_name in tc.columns
+            }
 
             for col in table.columns:
                 # A column absorbed into a sibling's composite-FK Referencing
@@ -489,45 +567,28 @@ class InductionStrategy(ABC):
                 om = URIRef(f"{pom}/ObjectMap")
                 g.add((pom, RR.objectMap, om))
 
-                # Check if this column is part of a composite FK
-                composite_fk = None
-                for tc in composite_fk_constraints:
-                    if col.name in tc.columns:
-                        composite_fk = tc
-                        break
+                # This column anchors a composite FK when the shared anchor table
+                # says so — never by re-deriving it here.
+                composite_fk = composite_anchors.get(col.name)
+
+                if col.name in malformed_composite_columns:
+                    # columns/referredColumns disagree in length, or the targets span
+                    # several tables: no join can be derived, so the column degrades
+                    # to a literal. composite_fk_columns reports these as
+                    # non-object-properties, keeping the ontology in step.
+                    log.warning(
+                        "Composite FK on %s is malformed (column/target counts differ, or targets span "
+                        "several tables); mapping %s as a literal",
+                        table.name,
+                        col.name,
+                    )
+                    g.add((om, RR.column, Literal(sql_ident(col.name))))
+                    g.add((om, RR.datatype, xsd_for_column(col.dataType, col.name)))
+                    continue
 
                 if composite_fk is not None and composite_fk.referredColumns:
                     # Composite FK: emit a single Referencing Object Map for the
                     # entire relationship, with one joinCondition per column pair.
-
-                    # Validate: columns and referredColumns must have equal length.
-                    if len(composite_fk.columns) != len(composite_fk.referredColumns):
-                        log.warning(
-                            "Skipping malformed composite FK on %s: columns/referredColumns length mismatch (%d vs %d)",
-                            table.name,
-                            len(composite_fk.columns),
-                            len(composite_fk.referredColumns),
-                        )
-                        composite_fk_constraints.remove(composite_fk)
-                        g.add((om, RR.column, Literal(sql_ident(col.name))))
-                        dt = xsd_for(col.dataType)
-                        g.add((om, RR.datatype, dt))
-                        continue
-
-                    # Validate: all referredColumns must reference the same target table.
-                    fk_tables = {parse_referred_column(rc)[0] for rc in composite_fk.referredColumns if "." in rc}
-                    if len(fk_tables) > 1:
-                        log.warning(
-                            "Skipping composite FK on %s: referredColumns span multiple tables %s",
-                            table.name,
-                            fk_tables,
-                        )
-                        composite_fk_constraints.remove(composite_fk)
-                        g.add((om, RR.column, Literal(sql_ident(col.name))))
-                        dt = xsd_for(col.dataType)
-                        g.add((om, RR.datatype, dt))
-                        continue
-
                     fk_target, _ = parse_referred_column(composite_fk.referredColumns[0])
                     parent_tmap = tmap_by_name.get(fk_target)
                     if parent_tmap is None:
@@ -546,8 +607,9 @@ class InductionStrategy(ABC):
                         g.add((jc, RR.child, Literal(sql_ident(child_col))))
                         g.add((jc, RR.parent, Literal(sql_ident(parent_col))))
 
-                    # Remove from composite list to avoid re-processing
-                    composite_fk_constraints.remove(composite_fk)
+                    # No bookkeeping needed: composite_fk_anchors already assigned
+                    # each constraint to exactly one column, so no other column can
+                    # re-emit this relationship.
                     continue
 
                 # Check for simple (single-column) FK

--- a/packages/ontology-engine/src/coa_ontology/inducer/strategies/rigor_ontology.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/strategies/rigor_ontology.py
@@ -29,7 +29,7 @@ from rdflib import OWL, RDF, RDFS, XSD, BNode, Graph, Literal, Namespace, URIRef
 from rdflib.namespace import SKOS
 
 from coa_ontology.inducer.schemas import ConceptMatch
-from coa_ontology.inducer.services.data_catalog import CatalogTable
+from coa_ontology.inducer.services.data_catalog import CatalogTable, parse_referred_column
 from coa_ontology.inducer.strategies.base import InductionStrategy
 
 log = logging.getLogger(__name__)
@@ -393,8 +393,7 @@ class RigorOntologyStrategy(InductionStrategy):
             if table and table.tableConstraints:
                 for tc in table.tableConstraints:
                     if tc.constraintType == "FOREIGN_KEY" and tc.referredColumns:
-                        # referredColumns entries look like "TableName.column"
-                        ref_table = tc.referredColumns[0].split(".")[0]
+                        ref_table, _ = parse_referred_column(tc.referredColumns[0])
                         if ref_table in table_map and ref_table != name:
                             visit(ref_table)
             in_progress.discard(name)
@@ -1010,8 +1009,5 @@ class RigorOntologyStrategy(InductionStrategy):
             return None, None
         for tc in table.tableConstraints:
             if tc.constraintType == "FOREIGN_KEY" and col_name in tc.columns and tc.referredColumns:
-                parts = tc.referredColumns[0].split(".")
-                target_table = parts[-2] if len(parts) >= 2 else parts[0]
-                target_pk = parts[-1]
-                return target_table, target_pk
+                return parse_referred_column(tc.referredColumns[0])
         return None, None

--- a/packages/ontology-engine/src/coa_ontology/inducer/strategies/table_to_ontology.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/strategies/table_to_ontology.py
@@ -24,7 +24,12 @@ from rdflib.namespace import SKOS
 from coa_ontology.inducer.schemas import ConceptMatch
 from coa_ontology.inducer.services.data_catalog import CatalogTable
 from coa_ontology.inducer.services.subtype_detection import detect_pk_sharing_subtypes
-from coa_ontology.inducer.strategies.base import SCL, InductionStrategy, pascal_names_for
+from coa_ontology.inducer.strategies.base import (
+    SCL,
+    InductionStrategy,
+    composite_fk_columns,
+    pascal_names_for,
+)
 
 log = logging.getLogger(__name__)
 
@@ -333,13 +338,23 @@ class TableToOntologyStrategy(InductionStrategy):
                         g.add((table_cls, OWL.hasKey, key_bnode))
                         break
 
+            # Columns absorbed into a sibling's composite-FK POM. build_r2rml emits
+            # ONE Referencing Object Map per composite FK (R2RML §7.5), anchored on
+            # the constraint's first column, so declaring an ObjectProperty for the
+            # others would mint properties with no mapping behind them — present in
+            # the TBox and in the NL→SPARQL context, but unresolvable by Ontop, so
+            # queries using them silently return nothing. Declare them as plain
+            # datatype properties instead: the columns do exist, they simply are not
+            # the relationship's anchor.
+            absorbed_fk_columns = composite_fk_columns(table)
+
             for col in table.columns:
                 prop_uri = table_prop(table.name, col.name)
                 is_fk = False
                 fk_target = None
                 fk_target_col = None
                 fk_provenance: str | None = None
-                if table.tableConstraints:
+                if table.tableConstraints and col.name not in absorbed_fk_columns:
                     for tc in table.tableConstraints:
                         if tc.constraintType == "FOREIGN_KEY" and col.name in tc.columns and tc.referredColumns:
                             is_fk = True
@@ -378,6 +393,21 @@ class TableToOntologyStrategy(InductionStrategy):
                     g.add((prop_uri, RDF.type, OWL.DatatypeProperty))
                     g.add((prop_uri, RDFS.domain, table_cls))
                     g.add((prop_uri, RDFS.range, _xsd_for(col.dataType, col.name)))
+                    if col.name in absorbed_fk_columns:
+                        # Record why an FK column is a datatype property, so the
+                        # relationship stays discoverable from the ontology alone.
+                        owner = absorbed_fk_columns[col.name]
+                        note = (
+                            f"Part of a composite foreign key on {table.name}; the relationship is carried by "
+                            f"{camel_by_name[table.name]}_{_to_camel(owner)}"
+                            if owner
+                            else (
+                                f"Part of a malformed composite foreign key on {table.name} "
+                                "(column/target counts differ, or targets span several tables); "
+                                "mapped as a literal because no join can be derived"
+                            )
+                        )
+                        g.add((prop_uri, RDFS.comment, Literal(note)))
 
                 g.add((prop_uri, RDFS.label, Literal(col.name)))
                 if col.description and not (is_fk and fk_target):

--- a/packages/ontology-engine/src/coa_ontology/inducer/strategies/table_to_ontology.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/strategies/table_to_ontology.py
@@ -27,8 +27,11 @@ from coa_ontology.inducer.services.subtype_detection import detect_pk_sharing_su
 from coa_ontology.inducer.strategies.base import (
     SCL,
     InductionStrategy,
+    composite_fk_anchors,
     composite_fk_columns,
     pascal_names_for,
+    reference_index,
+    table_identity,
 )
 
 log = logging.getLogger(__name__)
@@ -278,17 +281,30 @@ class TableToOntologyStrategy(InductionStrategy):
         # Collision-free class local names, shared with build_r2rml (base.py) and
         # the SHACL config generator so all three artifacts name the same class
         # identically. Bare _to_pascal would fuse tables differing only in
-        # separators/case (order_item vs order-item) onto one class IRI.
-        pascal_by_name = pascal_names_for(t.name for t in tables)
+        # separators/case (order_item vs order-item), or two same-named tables from
+        # different databases, onto one class IRI. Keyed by table IDENTITY.
+        pascal_by_id = pascal_names_for(tables)
         # Property local names are derived from the class local name (not from
         # _to_camel(table.name)) so a discriminated class carries discriminated
         # property IRIs too — otherwise the two fused tables' properties would
         # still collide even though their classes no longer do.
-        camel_by_name = {n: p[0].lower() + p[1:] if p else p for n, p in pascal_by_name.items()}
+        camel_by_id = {i: p[0].lower() + p[1:] if p else p for i, p in pascal_by_id.items()}
+        ref_index = reference_index(tables)
 
-        def table_prop(table_name: str, column_name: str) -> URIRef:
-            """Mint the property IRI for ``table_name.column_name``."""
-            return ns[f"{camel_by_name.get(table_name, _to_camel(table_name))}_{_to_camel(column_name)}"]
+        def table_prop(table: CatalogTable, column_name: str) -> URIRef:
+            """Mint the property IRI for ``table.column_name``."""
+            local = camel_by_id.get(table_identity(table), _to_camel(table.name))
+            return ns[f"{local}_{_to_camel(column_name)}"]
+
+        def parent_class(target_name: str, referrer: CatalogTable) -> URIRef:
+            """Resolve an FK target table name to its class IRI."""
+            qualified = f"{referrer.sourceSchema}.{target_name}" if referrer.sourceSchema else None
+            target_id = (qualified and ref_index.get(qualified)) or ref_index.get(target_name)
+            if target_id is not None and target_id in pascal_by_id:
+                return ns[pascal_by_id[target_id]]
+            # Outside this run, or an ambiguous bare name: fall back to the bare
+            # form, matching build_r2rml's parentTriplesMap fallback.
+            return ns[_to_pascal(target_name)]
 
         for table in tables:
             tm = match_map.get((table.name, ""))
@@ -297,7 +313,7 @@ class TableToOntologyStrategy(InductionStrategy):
             if not is_grounded:
                 novel_tables.add(table.name)
 
-            table_cls = ns[pascal_by_name[table.name]]
+            table_cls = ns[pascal_by_id[table_identity(table)]]
             g.add((table_cls, RDF.type, OWL.Class))
             g.add((table_cls, RDFS.label, Literal(table.name)))
             if table.description:
@@ -332,7 +348,7 @@ class TableToOntologyStrategy(InductionStrategy):
                     if tc.constraintType == "PRIMARY_KEY" and tc.columns:
                         from rdflib.collection import Collection
 
-                        key_props: list = [table_prop(table.name, c) for c in tc.columns]
+                        key_props: list = [table_prop(table, c) for c in tc.columns]
                         key_bnode = BNode()
                         Collection(g, key_bnode, key_props)
                         g.add((table_cls, OWL.hasKey, key_bnode))
@@ -347,25 +363,38 @@ class TableToOntologyStrategy(InductionStrategy):
             # datatype properties instead: the columns do exist, they simply are not
             # the relationship's anchor.
             absorbed_fk_columns = composite_fk_columns(table)
+            # Which column anchors which composite FK — the SAME helper build_r2rml
+            # consults. Resolving the target by "first FOREIGN_KEY constraint that
+            # lists this column" instead let the two artifacts disagree whenever a
+            # column belongs to more than one constraint: the ontology took whichever
+            # came first in ``tableConstraints`` while the mapping used the anchor, so
+            # ``rdfs:range`` and ``rr:parentTriplesMap`` named different parents.
+            composite_anchors = composite_fk_anchors(table)
 
             for col in table.columns:
-                prop_uri = table_prop(table.name, col.name)
+                prop_uri = table_prop(table, col.name)
                 is_fk = False
                 fk_target = None
                 fk_target_col = None
                 fk_provenance: str | None = None
                 if table.tableConstraints and col.name not in absorbed_fk_columns:
-                    for tc in table.tableConstraints:
-                        if tc.constraintType == "FOREIGN_KEY" and col.name in tc.columns and tc.referredColumns:
-                            is_fk = True
-                            fk_target, fk_target_col = parse_referred_column(tc.referredColumns[0])
-                            fk_provenance = tc.relationshipType
-                            break
+                    anchored = composite_anchors.get(col.name)
+                    if anchored is not None and anchored.referredColumns:
+                        is_fk = True
+                        fk_target, fk_target_col = parse_referred_column(anchored.referredColumns[0])
+                        fk_provenance = anchored.relationshipType
+                    else:
+                        for tc in table.tableConstraints:
+                            if tc.constraintType == "FOREIGN_KEY" and col.name in tc.columns and tc.referredColumns:
+                                is_fk = True
+                                fk_target, fk_target_col = parse_referred_column(tc.referredColumns[0])
+                                fk_provenance = tc.relationshipType
+                                break
 
                 if is_fk and fk_target:
                     # In-run tables use the shared (collision-resolved) name;
                     # a target outside this run falls back to the bare form.
-                    parent_cls = ns[pascal_by_name.get(fk_target, _to_pascal(fk_target))]
+                    parent_cls = parent_class(fk_target, table)
                     if (table.name, fk_target) in pk_sharing_confirmed:
                         g.add((table_cls, RDFS.subClassOf, parent_cls))
                         g.add((table_cls, SCL.subClassProvenance, Literal("PK_SHARING")))
@@ -397,7 +426,7 @@ class TableToOntologyStrategy(InductionStrategy):
                         owner = absorbed_fk_columns[col.name]
                         note = (
                             f"Part of a composite foreign key on {table.name}; the relationship is carried by "
-                            f"{camel_by_name[table.name]}_{_to_camel(owner)}"
+                            f"{camel_by_id[table_identity(table)]}_{_to_camel(owner)}"
                             if owner
                             else (
                                 f"Part of a malformed composite foreign key on {table.name} "

--- a/packages/ontology-engine/src/coa_ontology/inducer/strategies/table_to_ontology.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/strategies/table_to_ontology.py
@@ -22,7 +22,7 @@ from rdflib import OWL, RDF, RDFS, XSD, BNode, Graph, Literal, Namespace, URIRef
 from rdflib.namespace import SKOS
 
 from coa_ontology.inducer.schemas import ConceptMatch
-from coa_ontology.inducer.services.data_catalog import CatalogTable
+from coa_ontology.inducer.services.data_catalog import CatalogTable, parse_referred_column
 from coa_ontology.inducer.services.subtype_detection import detect_pk_sharing_subtypes
 from coa_ontology.inducer.strategies.base import (
     SCL,
@@ -358,9 +358,7 @@ class TableToOntologyStrategy(InductionStrategy):
                     for tc in table.tableConstraints:
                         if tc.constraintType == "FOREIGN_KEY" and col.name in tc.columns and tc.referredColumns:
                             is_fk = True
-                            parts = tc.referredColumns[0].split(".")
-                            fk_target = parts[-2] if len(parts) >= 2 else parts[0]
-                            fk_target_col = parts[-1] if len(parts) >= 2 else None
+                            fk_target, fk_target_col = parse_referred_column(tc.referredColumns[0])
                             fk_provenance = tc.relationshipType
                             break
 

--- a/packages/ontology-engine/src/coa_ontology/inducer/strategies/table_to_ontology.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/strategies/table_to_ontology.py
@@ -24,7 +24,7 @@ from rdflib.namespace import SKOS
 from coa_ontology.inducer.schemas import ConceptMatch
 from coa_ontology.inducer.services.data_catalog import CatalogTable
 from coa_ontology.inducer.services.subtype_detection import detect_pk_sharing_subtypes
-from coa_ontology.inducer.strategies.base import SCL, InductionStrategy
+from coa_ontology.inducer.strategies.base import SCL, InductionStrategy, pascal_names_for
 
 log = logging.getLogger(__name__)
 
@@ -270,6 +270,21 @@ class TableToOntologyStrategy(InductionStrategy):
         pk_sharing_confirmed, pk_sharing_suggested = detect_pk_sharing_subtypes(tables)
         novel_tables = set()
 
+        # Collision-free class local names, shared with build_r2rml (base.py) and
+        # the SHACL config generator so all three artifacts name the same class
+        # identically. Bare _to_pascal would fuse tables differing only in
+        # separators/case (order_item vs order-item) onto one class IRI.
+        pascal_by_name = pascal_names_for(t.name for t in tables)
+        # Property local names are derived from the class local name (not from
+        # _to_camel(table.name)) so a discriminated class carries discriminated
+        # property IRIs too — otherwise the two fused tables' properties would
+        # still collide even though their classes no longer do.
+        camel_by_name = {n: p[0].lower() + p[1:] if p else p for n, p in pascal_by_name.items()}
+
+        def table_prop(table_name: str, column_name: str) -> URIRef:
+            """Mint the property IRI for ``table_name.column_name``."""
+            return ns[f"{camel_by_name.get(table_name, _to_camel(table_name))}_{_to_camel(column_name)}"]
+
         for table in tables:
             tm = match_map.get((table.name, ""))
             is_grounded = tm and tm.match_type in ("exact", "high_confidence")
@@ -277,7 +292,7 @@ class TableToOntologyStrategy(InductionStrategy):
             if not is_grounded:
                 novel_tables.add(table.name)
 
-            table_cls = ns[_to_pascal(table.name)]
+            table_cls = ns[pascal_by_name[table.name]]
             g.add((table_cls, RDF.type, OWL.Class))
             g.add((table_cls, RDFS.label, Literal(table.name)))
             if table.description:
@@ -312,14 +327,14 @@ class TableToOntologyStrategy(InductionStrategy):
                     if tc.constraintType == "PRIMARY_KEY" and tc.columns:
                         from rdflib.collection import Collection
 
-                        key_props: list = [ns[f"{_to_camel(table.name)}_{_to_camel(c)}"] for c in tc.columns]
+                        key_props: list = [table_prop(table.name, c) for c in tc.columns]
                         key_bnode = BNode()
                         Collection(g, key_bnode, key_props)
                         g.add((table_cls, OWL.hasKey, key_bnode))
                         break
 
             for col in table.columns:
-                prop_uri = ns[f"{_to_camel(table.name)}_{_to_camel(col.name)}"]
+                prop_uri = table_prop(table.name, col.name)
                 is_fk = False
                 fk_target = None
                 fk_target_col = None
@@ -335,7 +350,9 @@ class TableToOntologyStrategy(InductionStrategy):
                             break
 
                 if is_fk and fk_target:
-                    parent_cls = ns[_to_pascal(fk_target)]
+                    # In-run tables use the shared (collision-resolved) name;
+                    # a target outside this run falls back to the bare form.
+                    parent_cls = ns[pascal_by_name.get(fk_target, _to_pascal(fk_target))]
                     if (table.name, fk_target) in pk_sharing_confirmed:
                         g.add((table_cls, RDFS.subClassOf, parent_cls))
                         g.add((table_cls, SCL.subClassProvenance, Literal("PK_SHARING")))

--- a/packages/ontology-engine/src/coa_ontology/validation/shapes/config.py
+++ b/packages/ontology-engine/src/coa_ontology/validation/shapes/config.py
@@ -20,6 +20,8 @@ from rdflib.namespace import RDF
 # (they lived in 3+ places). ``base.py`` owns the authoritative copies.
 from coa_ontology.inducer.services.data_catalog import parse_referred_column
 from coa_ontology.inducer.strategies.base import pascal_names_for as _pascal_names_for
+from coa_ontology.inducer.strategies.base import reference_index as _reference_index
+from coa_ontology.inducer.strategies.base import table_identity as _table_identity
 from coa_ontology.inducer.strategies.base import to_camel as _to_camel
 from coa_ontology.inducer.strategies.base import to_pascal as _to_pascal
 from coa_ontology.inducer.strategies.base import xsd_for as _xsd_for
@@ -100,11 +102,13 @@ def generate_config_from_db(tables, uri_prefix: str) -> ConstraintConfig:
 
     # Same collision-resolved local names the ontology and R2RML builders mint,
     # so the shapes target the classes/properties that actually exist.
-    pascal_by_name = _pascal_names_for(t.name for t in tables)
-    camel_by_name = {n: p[0].lower() + p[1:] if p else p for n, p in pascal_by_name.items()}
+    pascal_by_id = _pascal_names_for(tables)
+    camel_by_id = {i: p[0].lower() + p[1:] if p else p for i, p in pascal_by_id.items()}
+    ref_index = _reference_index(tables)
 
     for table in tables:
-        class_uri = f"{ns_str}{pascal_by_name[table.name]}"
+        identity = _table_identity(table)
+        class_uri = f"{ns_str}{pascal_by_id[identity]}"
         constraints: list[PropertyConstraint] = []
 
         pk_cols: set[str] = set()
@@ -123,7 +127,7 @@ def generate_config_from_db(tables, uri_prefix: str) -> ConstraintConfig:
                         fk_map[col_name] = fk_target
 
         for col in table.columns:
-            prop_path = f"{ns_str}{camel_by_name[table.name]}_{_to_camel(col.name)}"
+            prop_path = f"{ns_str}{camel_by_id[identity]}_{_to_camel(col.name)}"
             is_pk = col.name in pk_cols
             is_not_null = col.constraint in ("NOT_NULL", "PRIMARY_KEY") or is_pk
             is_unique = col.constraint in ("UNIQUE", "PRIMARY_KEY") or col.name in unique_cols or is_pk
@@ -153,7 +157,12 @@ def generate_config_from_db(tables, uri_prefix: str) -> ConstraintConfig:
 
             if is_fk:
                 fk_target_name = fk_map[col.name]
-                target_class = f"{ns_str}{pascal_by_name.get(fk_target_name, _to_pascal(fk_target_name))}"
+                # Resolve through the shared index so the shape targets the same
+                # class the ontology declared and the mapping joins to.
+                qualified = f"{table.sourceSchema}.{fk_target_name}" if table.sourceSchema else None
+                target_id = (qualified and ref_index.get(qualified)) or ref_index.get(fk_target_name)
+                target_local = pascal_by_id[target_id] if target_id in pascal_by_id else _to_pascal(fk_target_name)
+                target_class = f"{ns_str}{target_local}"
                 constraints.append(
                     PropertyConstraint(
                         property_path=prop_path,

--- a/packages/ontology-engine/src/coa_ontology/validation/shapes/config.py
+++ b/packages/ontology-engine/src/coa_ontology/validation/shapes/config.py
@@ -18,6 +18,7 @@ from rdflib.namespace import RDF
 
 # Reuse the canonical SQL→XSD map + naming helpers rather than redefining them
 # (they lived in 3+ places). ``base.py`` owns the authoritative copies.
+from coa_ontology.inducer.services.data_catalog import parse_referred_column
 from coa_ontology.inducer.strategies.base import pascal_names_for as _pascal_names_for
 from coa_ontology.inducer.strategies.base import to_camel as _to_camel
 from coa_ontology.inducer.strategies.base import to_pascal as _to_pascal
@@ -117,9 +118,7 @@ def generate_config_from_db(tables, uri_prefix: str) -> ConstraintConfig:
                 elif tc.constraintType == "UNIQUE" and tc.columns and len(tc.columns) == 1:
                     unique_cols.update(tc.columns)
                 elif tc.constraintType == "FOREIGN_KEY" and tc.columns and tc.referredColumns:
-                    ref = tc.referredColumns[0]
-                    parts = ref.split(".")
-                    fk_target = parts[-2] if len(parts) >= 2 else ref
+                    fk_target, _ = parse_referred_column(tc.referredColumns[0])
                     for col_name in tc.columns:
                         fk_map[col_name] = fk_target
 

--- a/packages/ontology-engine/src/coa_ontology/validation/shapes/config.py
+++ b/packages/ontology-engine/src/coa_ontology/validation/shapes/config.py
@@ -18,6 +18,7 @@ from rdflib.namespace import RDF
 
 # Reuse the canonical SQL→XSD map + naming helpers rather than redefining them
 # (they lived in 3+ places). ``base.py`` owns the authoritative copies.
+from coa_ontology.inducer.strategies.base import pascal_names_for as _pascal_names_for
 from coa_ontology.inducer.strategies.base import to_camel as _to_camel
 from coa_ontology.inducer.strategies.base import to_pascal as _to_pascal
 from coa_ontology.inducer.strategies.base import xsd_for as _xsd_for
@@ -96,8 +97,13 @@ def generate_config_from_db(tables, uri_prefix: str) -> ConstraintConfig:
     ns_str = uri_prefix
     classes: list[ClassConstraints] = []
 
+    # Same collision-resolved local names the ontology and R2RML builders mint,
+    # so the shapes target the classes/properties that actually exist.
+    pascal_by_name = _pascal_names_for(t.name for t in tables)
+    camel_by_name = {n: p[0].lower() + p[1:] if p else p for n, p in pascal_by_name.items()}
+
     for table in tables:
-        class_uri = f"{ns_str}{_to_pascal(table.name)}"
+        class_uri = f"{ns_str}{pascal_by_name[table.name]}"
         constraints: list[PropertyConstraint] = []
 
         pk_cols: set[str] = set()
@@ -118,7 +124,7 @@ def generate_config_from_db(tables, uri_prefix: str) -> ConstraintConfig:
                         fk_map[col_name] = fk_target
 
         for col in table.columns:
-            prop_path = f"{ns_str}{_to_camel(table.name)}_{_to_camel(col.name)}"
+            prop_path = f"{ns_str}{camel_by_name[table.name]}_{_to_camel(col.name)}"
             is_pk = col.name in pk_cols
             is_not_null = col.constraint in ("NOT_NULL", "PRIMARY_KEY") or is_pk
             is_unique = col.constraint in ("UNIQUE", "PRIMARY_KEY") or col.name in unique_cols or is_pk
@@ -147,7 +153,8 @@ def generate_config_from_db(tables, uri_prefix: str) -> ConstraintConfig:
                 )
 
             if is_fk:
-                target_class = f"{ns_str}{_to_pascal(fk_map[col.name])}"
+                fk_target_name = fk_map[col.name]
+                target_class = f"{ns_str}{pascal_by_name.get(fk_target_name, _to_pascal(fk_target_name))}"
                 constraints.append(
                     PropertyConstraint(
                         property_path=prop_path,

--- a/packages/ontology-engine/tests/unit/test_datatype_canonicalizer.py
+++ b/packages/ontology-engine/tests/unit/test_datatype_canonicalizer.py
@@ -198,3 +198,97 @@ class TestDetectDatatypeIssuesInTurtle:
         assert detect_datatype_issues_in_turtle(None) == []
         assert detect_datatype_issues_in_turtle("") == []
         assert detect_datatype_issues_in_turtle("this is not turtle {{{") == []
+
+
+class TestLiteralValuePreservation:
+    """A datatype repair must never alter or invalidate the literal's value.
+
+    The alias table maps SQL type names onto XSD types with much narrower lexical
+    spaces (bigint→long, number→decimal, timestamp→dateTime). Rewriting the
+    datatype alone turned "abc"^^xsd:bigint into the ill-typed "abc"^^xsd:long,
+    and constructing the replacement Literal without normalize=False rewrote
+    "2024-01-15" to "2024-01-15T00:00:00". Both are irreversible: this module runs
+    at the persist boundary and drops the original token.
+    """
+
+    def test_incompatible_value_is_left_untouched(self):
+        g = Graph()
+        g.add((S, P, Literal("abc", datatype=URIRef(f"{XSD}bigint"))))
+
+        changes = canonicalize_datatypes(g)
+
+        assert changes == [], "must not rewrite a token whose value would become ill-typed"
+        assert (S, P, Literal("abc", datatype=URIRef(f"{XSD}bigint"))) in g
+
+    def test_incompatible_value_never_yields_an_ill_typed_literal(self):
+        g = Graph()
+        g.add((S, P, Literal("abc", datatype=URIRef(f"{XSD}bigint"))))
+
+        canonicalize_datatypes(g)
+
+        for _s, _p, o in g:
+            assert not (isinstance(o, Literal) and o.ill_typed), f"produced ill-typed literal: {o!r}"
+
+    def test_lexical_form_survives_a_compatible_repair(self):
+        """timestamp→dateTime must not reformat the value."""
+        g = Graph()
+        g.add((S, P, Literal("2024-01-15", datatype=URIRef(f"{XSD}timestamp"))))
+
+        canonicalize_datatypes(g)
+
+        obj = next(o for _s, _p, o in g)
+        assert str(obj) == "2024-01-15", f"lexical form was rewritten to {str(obj)!r}"
+        assert obj.datatype == XSD.dateTime
+
+    def test_compatible_values_are_still_repaired(self):
+        """The guard must not disable the repair it is protecting."""
+        g = Graph()
+        g.add((S, P, Literal("hello", datatype=URIRef(f"{XSD}varchar"))))
+        g.add((URIRef("http://x#b"), P, Literal("42.5", datatype=URIRef(f"{XSD}number"))))
+
+        changes = canonicalize_datatypes(g)
+
+        assert len(changes) == 2
+        datatypes = {o.datatype for _s, _p, o in g}
+        assert datatypes == {XSD.string, XSD.decimal}
+
+    def test_incompatible_token_is_still_reported_to_the_user(self):
+        """Skipping the repair must not hide the malformed token."""
+        g = Graph()
+        g.add((S, P, Literal("abc", datatype=URIRef(f"{XSD}bigint"))))
+
+        issues = detect_datatype_issues(g)
+
+        assert len(issues) == 1
+        assert issues[0]["found"] == f"{XSD}bigint"
+        assert issues[0]["repairable"] == "false"
+
+    def test_repairable_flag_is_true_for_a_safe_rewrite(self):
+        g = Graph()
+        g.add((S, P, Literal("hello", datatype=URIRef(f"{XSD}varchar"))))
+
+        issues = detect_datatype_issues(g)
+
+        assert issues[0]["repairable"] == "true"
+
+    def test_datatype_uri_objects_are_unaffected_by_the_guard(self):
+        """rdfs:range / rr:datatype carry no value, so they always repair."""
+        g = Graph()
+        g.add((S, RDFS.range, URIRef(f"{XSD}bigint")))
+
+        changes = canonicalize_datatypes(g)
+
+        assert changes == [(f"{XSD}bigint", f"{XSD}long")]
+        assert (S, RDFS.range, XSD.long) in g
+
+    def test_turtle_round_trip_preserves_an_incompatible_literal(self):
+        ttl = (
+            "@prefix ex: <http://ex.org/> .\n"
+            "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n"
+            'ex:a ex:p "abc"^^xsd:bigint .\n'
+        )
+
+        out, changes = canonicalize_turtle(ttl)
+
+        assert changes == []
+        assert out == ttl, "a graph with nothing safely repairable must keep its bytes"

--- a/packages/ontology-engine/tests/unit/test_dynamo_store.py
+++ b/packages/ontology-engine/tests/unit/test_dynamo_store.py
@@ -733,6 +733,90 @@ class TestListProposalsScanPaginationDrain:
         assert {r["proposal_id"] for r in rows} == {"p1", "p2", "p3"}
 
 
+class TestListNamespacesScanPagination:
+    """``list_namespaces`` must follow ``LastEvaluatedKey``.
+
+    DynamoDB applies ``Limit`` to items EVALUATED before filtering, not to matches
+    returned. This single-table design stores job / proposal / ingest-job rows
+    alongside the ``NAMESPACE#`` ones, so once the table holds more non-namespace
+    rows than the limit, a single-page scan returns few or zero namespaces and
+    silently omits the rest — driven by TOTAL item count, not namespace count.
+    """
+
+    @staticmethod
+    def _seed_namespace(table, name: str) -> None:
+        table.put_item(Item={"PK": f"NAMESPACE#{name}", "SK": "META", "namespace": name})
+
+    @staticmethod
+    def _seed_noise(table, n: int) -> None:
+        """Non-namespace rows of the kind that accumulate in normal use."""
+        for i in range(n):
+            table.put_item(Item={"PK": f"NS#x#JOB#{i}", "SK": "STATUS", "job_id": str(i)})
+
+    def test_namespace_on_a_later_page_is_returned(self, monkeypatch):
+        from coa_ontology import dynamo_store as ds
+
+        table = _FakeDynamoTable(page_size=2)
+        self._seed_namespace(table, "ns-a")
+        self._seed_namespace(table, "ns-b")
+        self._seed_namespace(table, "ns-c")  # lands on page 2
+        monkeypatch.setattr(ds, "_get_table", lambda: table)
+
+        rows = ds.list_namespaces()
+
+        assert {r["namespace"] for r in rows} == {"ns-a", "ns-b", "ns-c"}
+
+    def test_namespaces_hidden_behind_unrelated_rows_are_still_found(self, monkeypatch):
+        """The actual production failure mode.
+
+        The old code passed ``Limit=limit`` (100), and DynamoDB applies Limit to
+        items EVALUATED, so with >100 job/proposal rows ahead of the namespace rows
+        the single page it read contained no namespaces at all. Seeds past the
+        default limit so the first evaluated page is entirely noise.
+        """
+        from coa_ontology import dynamo_store as ds
+
+        table = _FakeDynamoTable(page_size=40)
+        self._seed_noise(table, 150)  # more than the default limit of 100
+        self._seed_namespace(table, "ns-late")
+        monkeypatch.setattr(ds, "_get_table", lambda: table)
+
+        rows = ds.list_namespaces()
+
+        assert {r["namespace"] for r in rows} == {"ns-late"}
+
+    def test_limit_still_caps_the_result(self, monkeypatch):
+        from coa_ontology import dynamo_store as ds
+
+        table = _FakeDynamoTable(page_size=2)
+        for i in range(5):
+            self._seed_namespace(table, f"ns-{i}")
+        monkeypatch.setattr(ds, "_get_table", lambda: table)
+
+        assert len(ds.list_namespaces(limit=3)) == 3
+
+    def test_only_namespace_meta_rows_are_returned(self, monkeypatch):
+        from coa_ontology import dynamo_store as ds
+
+        table = _FakeDynamoTable(page_size=3)
+        self._seed_namespace(table, "ns-a")
+        self._seed_noise(table, 4)
+        # A NAMESPACE# partition row that is not the META row must not match.
+        table.put_item(Item={"PK": "NAMESPACE#ns-a", "SK": "OTHER", "namespace": "ns-a"})
+        monkeypatch.setattr(ds, "_get_table", lambda: table)
+
+        rows = ds.list_namespaces()
+
+        assert [r["SK"] for r in rows] == ["META"]
+
+    def test_empty_table_returns_empty(self, monkeypatch):
+        from coa_ontology import dynamo_store as ds
+
+        monkeypatch.setattr(ds, "_get_table", lambda: _FakeDynamoTable(page_size=2))
+
+        assert ds.list_namespaces() == []
+
+
 class TestListProposalsCrossNamespaceContainsFilter:
     """``list_proposals(namespace=None)`` filters on ``contains(PK, "#PROPOSAL#")``.
 

--- a/packages/ontology-engine/tests/unit/test_r2rml_spec_compliance.py
+++ b/packages/ontology-engine/tests/unit/test_r2rml_spec_compliance.py
@@ -1026,12 +1026,18 @@ class TestForeignKeyObjectMaps:
         conditions = _object_map_join_conditions(g, ns["TriplesMap_Bookings/POM_BookingDay"])
         assert conditions == [('"booking_day"', '"day"'), ('"booking_hour"', '"hour"')]
 
-        # booking_hour does NOT get its own POM (it's part of the composite)
-        all_poms = list(g.objects(ns.TriplesMap_Bookings, RR.predicateObjectMap))
-        pom_uris = [str(p) for p in all_poms]
-        assert not any("POM_BookingHour" in uri for uri in pom_uris), (
-            "booking_hour should NOT have its own POM — it's part of the composite FK"
+        # booking_hour does NOT get a second REFERENCING map — the relationship is
+        # expressed once, on booking_day (R2RML §7.5).
+        hour_pom = ns["TriplesMap_Bookings/POM_BookingHour"]
+        assert _object_map_parent_tmap(g, hour_pom) is None, (
+            "the composite relationship must be carried by exactly one referencing object map"
         )
+
+        # It DOES get a literal mapping. The ontology declares a property for
+        # every column, so leaving booking_hour unmapped left that declaration
+        # with nothing behind it and any SPARQL using it returned nothing.
+        assert _object_map_column(g, hour_pom) == '"booking_hour"'
+        assert _object_map_datatype(g, hour_pom) == XSD.integer
 
     def test_composite_fk_three_columns(self, strategy):
         """Composite FK with 3 columns produces single POM with 3 joinConditions."""
@@ -2149,3 +2155,203 @@ class TestPascalCaseCollisions:
         shape_classes = {URIRef(c.class_uri) for c in config.classes}
         assert shape_classes <= onto_classes, f"Shapes target absent classes: {shape_classes - onto_classes}"
         assert len(shape_classes) == 2
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# SECTION 11: ontology / R2RML property parity
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+class TestOntologyR2rmlParity:
+    """Every property the ontology declares must have a mapping behind it.
+
+    A declared-but-unmapped property is worse than a missing one: it shows up in
+    the class/property browser and in the TBox context handed to the NL→SPARQL
+    LLM, so the model is encouraged to author SPARQL against a property Ontop
+    cannot resolve. The query compiles and returns nothing, with no mapping-gap
+    signal anywhere.
+    """
+
+    @staticmethod
+    def _declared_properties(onto):
+        return {str(p) for p in onto.subjects(RDF.type, OWL.ObjectProperty)} | {
+            str(p) for p in onto.subjects(RDF.type, OWL.DatatypeProperty)
+        }
+
+    @staticmethod
+    def _mapped_predicates(r2rml):
+        return {str(p) for _, _, p in r2rml.triples((None, RR.predicate, None))}
+
+    def _both(self, strategy, tables):
+        onto, novel = strategy._build_proposal_ontology(PREFIX, tables, [])
+        r2rml = strategy.build_r2rml(PREFIX, tables, novel, onto)
+        return onto, r2rml
+
+    @staticmethod
+    def _composite_fk_tables(*, arity: int = 2):
+        cols = [("day", "VARCHAR"), ("hour", "INT"), ("minute", "INT")][:arity]
+        parent = CatalogTable(
+            id="1",
+            name="time_slots",
+            fullyQualifiedName="s.time_slots",
+            columns=[CatalogColumn(name=n, dataType=t) for n, t in cols]
+            + [CatalogColumn(name="room", dataType="VARCHAR")],
+            tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=[n for n, _ in cols])],
+        )
+        child = CatalogTable(
+            id="2",
+            name="bookings",
+            fullyQualifiedName="s.bookings",
+            columns=[CatalogColumn(name="booking_id", dataType="INT")]
+            + [CatalogColumn(name=n, dataType=t) for n, t in cols]
+            + [CatalogColumn(name="note", dataType="VARCHAR")],
+            tableConstraints=[
+                CatalogConstraint(constraintType="PRIMARY_KEY", columns=["booking_id"]),
+                CatalogConstraint(
+                    constraintType="FOREIGN_KEY",
+                    columns=[n for n, _ in cols],
+                    referredColumns=[f"time_slots.{n}" for n, _ in cols],
+                ),
+            ],
+        )
+        return [parent, child]
+
+    def test_composite_fk_leaves_no_unmapped_property(self, strategy):
+        onto, r2rml = self._both(strategy, self._composite_fk_tables())
+
+        unmapped = self._declared_properties(onto) - self._mapped_predicates(r2rml)
+        assert unmapped == set(), f"ontology declares properties with no R2RML mapping: {sorted(unmapped)}"
+
+    def test_three_column_composite_fk_leaves_no_unmapped_property(self, strategy):
+        """The gap scaled with arity — a 3-column FK orphaned two properties."""
+        onto, r2rml = self._both(strategy, self._composite_fk_tables(arity=3))
+
+        unmapped = self._declared_properties(onto) - self._mapped_predicates(r2rml)
+        assert unmapped == set(), f"ontology declares properties with no R2RML mapping: {sorted(unmapped)}"
+
+    def test_absorbed_column_is_a_datatype_property_not_an_object_property(self, strategy):
+        """The relationship is carried once; the other columns are plain literals."""
+        onto, _ = self._both(strategy, self._composite_fk_tables())
+        ns = Namespace(PREFIX)
+
+        assert (ns.bookings_day, RDF.type, OWL.ObjectProperty) in onto
+        assert (ns.bookings_hour, RDF.type, OWL.DatatypeProperty) in onto
+        assert (ns.bookings_hour, RDF.type, OWL.ObjectProperty) not in onto
+
+    def test_absorbed_column_range_matches_its_r2rml_datatype(self, strategy):
+        """rdfs:range and rr:datatype must agree or Ontop's type reasoning drops rows."""
+        onto, r2rml = self._both(strategy, self._composite_fk_tables())
+        ns = Namespace(PREFIX)
+
+        onto_range = onto.value(ns.bookings_hour, RDFS.range)
+        r2rml_datatype = _object_map_datatype(r2rml, ns["TriplesMap_Bookings/POM_Hour"])
+        assert onto_range == r2rml_datatype == XSD.integer
+
+    def test_absorbed_column_documents_where_the_relationship_lives(self, strategy):
+        onto, _ = self._both(strategy, self._composite_fk_tables())
+        ns = Namespace(PREFIX)
+
+        comment = str(onto.value(ns.bookings_hour, RDFS.comment))
+        assert "composite foreign key" in comment
+        assert "bookings_day" in comment
+
+    # ── malformed composite FKs degrade consistently on BOTH sides ────────────
+
+    @staticmethod
+    def _malformed_tables(*, referred):
+        return [
+            CatalogTable(
+                id="1",
+                name="bookings",
+                fullyQualifiedName="s.bookings",
+                columns=[
+                    CatalogColumn(name="day", dataType="VARCHAR"),
+                    CatalogColumn(name="hour", dataType="INT"),
+                ],
+                tableConstraints=[
+                    CatalogConstraint(
+                        constraintType="FOREIGN_KEY",
+                        columns=["day", "hour"],
+                        referredColumns=referred,
+                    )
+                ],
+            )
+        ]
+
+    def test_length_mismatch_degrades_to_datatype_on_both_sides(self, strategy):
+        """build_r2rml falls back to literals; the ontology must not claim a relationship."""
+        onto, r2rml = self._both(strategy, self._malformed_tables(referred=["slots.day"]))
+        ns = Namespace(PREFIX)
+
+        assert (ns.bookings_day, RDF.type, OWL.DatatypeProperty) in onto
+        assert (ns.bookings_day, RDF.type, OWL.ObjectProperty) not in onto
+        assert onto.value(ns.bookings_day, RDFS.range) == XSD.string
+        assert _object_map_datatype(r2rml, ns["TriplesMap_Bookings/POM_Day"]) == XSD.string
+
+    def test_multi_table_targets_degrade_to_datatype_on_both_sides(self, strategy):
+        onto, r2rml = self._both(strategy, self._malformed_tables(referred=["a.day", "b.hour"]))
+        ns = Namespace(PREFIX)
+
+        for local, expected in (("bookings_day", XSD.string), ("bookings_hour", XSD.integer)):
+            assert (ns[local], RDF.type, OWL.DatatypeProperty) in onto
+            assert onto.value(ns[local], RDFS.range) == expected
+
+    def test_malformed_composite_fk_leaves_no_unmapped_property(self, strategy):
+        onto, r2rml = self._both(strategy, self._malformed_tables(referred=["slots.day"]))
+
+        unmapped = self._declared_properties(onto) - self._mapped_predicates(r2rml)
+        assert unmapped == set(), f"unmapped after malformed-FK fallback: {sorted(unmapped)}"
+
+    # ── the simple cases must be untouched ───────────────────────────────────
+
+    def test_simple_fk_still_yields_an_object_property(self, strategy):
+        tables = [
+            CatalogTable(
+                id="1",
+                name="orders",
+                fullyQualifiedName="s.orders",
+                columns=[
+                    CatalogColumn(name="id", dataType="INT"),
+                    CatalogColumn(name="customer_id", dataType="INT"),
+                ],
+                tableConstraints=[
+                    CatalogConstraint(constraintType="PRIMARY_KEY", columns=["id"]),
+                    CatalogConstraint(
+                        constraintType="FOREIGN_KEY",
+                        columns=["customer_id"],
+                        referredColumns=["customers.id"],
+                    ),
+                ],
+            ),
+            CatalogTable(
+                id="2",
+                name="customers",
+                fullyQualifiedName="s.customers",
+                columns=[CatalogColumn(name="id", dataType="INT")],
+                tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=["id"])],
+            ),
+        ]
+        onto, r2rml = self._both(strategy, tables)
+        ns = Namespace(PREFIX)
+
+        assert (ns.orders_customerId, RDF.type, OWL.ObjectProperty) in onto
+        assert _object_map_parent_tmap(r2rml, ns["TriplesMap_Orders/POM_CustomerId"]) == ns.TriplesMap_Customers
+        assert self._declared_properties(onto) - self._mapped_predicates(r2rml) == set()
+
+    def test_no_fk_table_has_full_parity(self, strategy):
+        tables = [
+            CatalogTable(
+                id="1",
+                name="statuses",
+                fullyQualifiedName="s.statuses",
+                columns=[
+                    CatalogColumn(name="code", dataType="VARCHAR"),
+                    CatalogColumn(name="label", dataType="VARCHAR"),
+                ],
+                tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=["code"])],
+            )
+        ]
+        onto, r2rml = self._both(strategy, tables)
+
+        assert self._declared_properties(onto) - self._mapped_predicates(r2rml) == set()

--- a/packages/ontology-engine/tests/unit/test_r2rml_spec_compliance.py
+++ b/packages/ontology-engine/tests/unit/test_r2rml_spec_compliance.py
@@ -2507,3 +2507,118 @@ class TestReferredColumnParsing:
 
         assert ("loss_payment", "claim_amount") in confirmed
         assert ("expense_payment", "claim_amount") in confirmed
+
+
+@pytest.mark.unit
+class TestOverlappingCompositeForeignKeys:
+    """Two composite FKs sharing a column must both keep their relationship.
+
+    `build_r2rml` walks the columns and CONSUMES each constraint as it anchors it,
+    so for FK1=(a,b)->p1 and FK2=(b,c)->p2: `a` anchors FK1 (absorbing `b`), and
+    `c` — reached with FK1 already consumed — anchors FK2.
+
+    A non-consuming `composite_fk_columns` matched `c` against FK2 while also
+    treating it as absorbed by `b`, so `c` degraded to a literal and the child→p2
+    relationship vanished from the R2RML mapping AND (since both builders share the
+    helper) from the ontology.
+    """
+
+    @staticmethod
+    def _tables():
+        child = CatalogTable(
+            id="1",
+            name="child",
+            fullyQualifiedName="s.child",
+            columns=[
+                CatalogColumn(name="a", dataType="INT"),
+                CatalogColumn(name="b", dataType="INT"),
+                CatalogColumn(name="c", dataType="INT"),
+            ],
+            tableConstraints=[
+                CatalogConstraint(constraintType="FOREIGN_KEY", columns=["a", "b"], referredColumns=["p1.a", "p1.b"]),
+                CatalogConstraint(constraintType="FOREIGN_KEY", columns=["b", "c"], referredColumns=["p2.b", "p2.c"]),
+            ],
+        )
+        p1 = CatalogTable(
+            id="2",
+            name="p1",
+            fullyQualifiedName="s.p1",
+            columns=[CatalogColumn(name="a", dataType="INT"), CatalogColumn(name="b", dataType="INT")],
+            tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=["a", "b"])],
+        )
+        p2 = CatalogTable(
+            id="3",
+            name="p2",
+            fullyQualifiedName="s.p2",
+            columns=[CatalogColumn(name="b", dataType="INT"), CatalogColumn(name="c", dataType="INT")],
+            tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=["b", "c"])],
+        )
+        return [child, p1, p2]
+
+    def test_both_relationships_survive_in_r2rml(self, strategy):
+        g = _build(strategy, self._tables())
+        ns = Namespace(PREFIX)
+
+        parents = {str(p) for _, _, p in g.triples((None, RR.parentTriplesMap, None))}
+        assert str(ns.TriplesMap_P1) in parents
+        assert str(ns.TriplesMap_P2) in parents, "the second composite FK's relationship was dropped"
+
+    def test_each_composite_fk_is_anchored_on_a_distinct_column(self, strategy):
+        g = _build(strategy, self._tables())
+        ns = Namespace(PREFIX)
+
+        assert _object_map_parent_tmap(g, ns["TriplesMap_Child/POM_A"]) == ns.TriplesMap_P1
+        assert _object_map_parent_tmap(g, ns["TriplesMap_Child/POM_C"]) == ns.TriplesMap_P2
+        # b is absorbed by FK1's map and carries a literal mapping only.
+        assert _object_map_parent_tmap(g, ns["TriplesMap_Child/POM_B"]) is None
+        assert _object_map_column(g, ns["TriplesMap_Child/POM_B"]) == '"b"'
+
+    def test_shared_column_is_absorbed_exactly_once(self, strategy):
+        from coa_ontology.inducer.strategies.base import composite_fk_columns
+
+        child = self._tables()[0]
+
+        assert composite_fk_columns(child) == {"b": "a"}
+
+    def test_ontology_matches_the_mapping(self, strategy):
+        tables = self._tables()
+        onto, novel = strategy._build_proposal_ontology(PREFIX, tables, [])
+        r2rml = strategy.build_r2rml(PREFIX, tables, novel, onto)
+        ns = Namespace(PREFIX)
+
+        assert (ns.child_a, RDF.type, OWL.ObjectProperty) in onto
+        assert (ns.child_c, RDF.type, OWL.ObjectProperty) in onto
+        assert (ns.child_b, RDF.type, OWL.DatatypeProperty) in onto
+        assert onto.value(ns.child_c, RDFS.range) == ns.P2
+
+        declared = {str(p) for p in onto.subjects(RDF.type, OWL.ObjectProperty)} | {
+            str(p) for p in onto.subjects(RDF.type, OWL.DatatypeProperty)
+        }
+        mapped = {str(p) for _, _, p in r2rml.triples((None, RR.predicate, None))}
+        assert declared - mapped == set()
+
+    def test_three_overlapping_composite_fks(self, strategy):
+        """Chained overlap: (a,b)->p1, (b,c)->p2, (c,d)->p3."""
+        child = CatalogTable(
+            id="1",
+            name="child",
+            fullyQualifiedName="s.child",
+            columns=[CatalogColumn(name=n, dataType="INT") for n in ("a", "b", "c", "d")],
+            tableConstraints=[
+                CatalogConstraint(constraintType="FOREIGN_KEY", columns=["a", "b"], referredColumns=["p1.a", "p1.b"]),
+                CatalogConstraint(constraintType="FOREIGN_KEY", columns=["b", "c"], referredColumns=["p2.b", "p2.c"]),
+                CatalogConstraint(constraintType="FOREIGN_KEY", columns=["c", "d"], referredColumns=["p3.c", "p3.d"]),
+            ],
+        )
+        g = _build(strategy, [child])
+
+        ns = Namespace(PREFIX)
+        # a anchors FK1 (folding in b); b is skipped as folded, so c anchors FK2
+        # (folding in nothing new); d then anchors FK3. Every constraint keeps a
+        # relationship — matches what the pre-fix mapping emitted, verified by
+        # running both revisions.
+        assert _object_map_parent_tmap(g, ns["TriplesMap_Child/POM_A"]) == ns.TriplesMap_P1
+        assert _object_map_parent_tmap(g, ns["TriplesMap_Child/POM_C"]) == ns.TriplesMap_P2
+        assert _object_map_parent_tmap(g, ns["TriplesMap_Child/POM_D"]) == ns.TriplesMap_P3
+        # b is the only folded column, so it is the only literal.
+        assert _object_map_column(g, ns["TriplesMap_Child/POM_B"]) == '"b"'

--- a/packages/ontology-engine/tests/unit/test_r2rml_spec_compliance.py
+++ b/packages/ontology-engine/tests/unit/test_r2rml_spec_compliance.py
@@ -2078,8 +2078,15 @@ class TestPascalCaseCollisions:
         assert (ns.TriplesMap_Orders, RDF.type, RR.TriplesMap) in g
         assert (ns.TriplesMap_Customers, RDF.type, RR.TriplesMap) in g
 
-    def test_first_colliding_table_keeps_the_bare_iri(self, strategy):
-        """Existing deployments keep byte-identical IRIs for the first name."""
+    def test_the_lowest_identity_keeps_the_bare_iri(self, strategy):
+        """The bare form is assigned by identity, never by input order.
+
+        Order would be the obvious rule and is the wrong one: ``_catalog_to_tables``
+        emits tables in whatever order the catalog enumerated them, so an
+        order-dependent assignment moves the bare IRI to a different table when that
+        order changes and a freshly generated mapping stops matching an
+        already-accepted ontology.
+        """
         tables = self._tables("order_item", "order-item")
         g = _build(strategy, tables)
         ns = Namespace(PREFIX)
@@ -2088,7 +2095,20 @@ class TestPascalCaseCollisions:
         names = [
             str(n) for lt in g.objects(ns.TriplesMap_OrderItem, RR.logicalTable) for n in g.objects(lt, RR.tableName)
         ]
-        assert names == ['"order_item"']
+        # min("db.order-item", "db.order_item") — "-" sorts before "_".
+        assert names == ['"order-item"']
+
+    def test_assignment_does_not_depend_on_input_order(self, strategy):
+        """Reversing the caller's list must mint exactly the same IRIs."""
+        forward = _build(strategy, self._tables("order_item", "order-item"))
+        reverse = _build(strategy, self._tables("order-item", "order_item"))
+
+        assert set(forward.subjects(RDF.type, RR.TriplesMap)) == set(reverse.subjects(RDF.type, RR.TriplesMap))
+        # Not just the same IRIs — the same table behind each one.
+        for tmap in forward.subjects(RDF.type, RR.TriplesMap):
+            fwd = [str(n) for lt in forward.objects(tmap, RR.logicalTable) for n in forward.objects(lt, RR.tableName)]
+            rev = [str(n) for lt in reverse.objects(tmap, RR.logicalTable) for n in reverse.objects(lt, RR.tableName)]
+            assert fwd == rev, f"{tmap} maps {fwd} one way and {rev} the other"
 
     def test_assignment_is_deterministic_across_runs(self, strategy):
         """Same input order must mint the same IRIs every time."""
@@ -2622,3 +2642,246 @@ class TestOverlappingCompositeForeignKeys:
         assert _object_map_parent_tmap(g, ns["TriplesMap_Child/POM_D"]) == ns.TriplesMap_P3
         # b is the only folded column, so it is the only literal.
         assert _object_map_column(g, ns["TriplesMap_Child/POM_B"]) == '"b"'
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# SECTION 13: A column in a malformed FK that also anchors a well-formed one
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestMalformedAndUsableCompositeFksShareAColumn:
+    """A broken constraint must not cost an unrelated, expressible relationship.
+
+    ``build_r2rml`` degrades every column of a malformed composite FK to a literal,
+    and ``composite_fk_anchors`` assigns anchors for the usable ones. A column can be
+    in both sets. The malformed check used to run FIRST, so such a column was emitted
+    as ``rr:column`` + ``rr:datatype`` — while the ontology, which asks
+    ``composite_fk_anchors``, still declared it an ``owl:ObjectProperty`` with
+    ``rdfs:range <Parent>``. That is the ontology/mapping contradiction the
+    composite-FK work set out to remove, reintroduced through a different door, and
+    it silently dropped the usable FK's relationship from the mapping entirely: the
+    anchor was consumed, so no other column re-emitted it.
+    """
+
+    @staticmethod
+    def _tables():
+        # Column order matters: `c` must be the first column of a usable composite
+        # FK so `composite_fk_anchors` picks it as the anchor.
+        child = CatalogTable(
+            id="1",
+            name="child",
+            fullyQualifiedName="s.child",
+            columns=[CatalogColumn(name=n, dataType="INT") for n in ("c", "a", "d")],
+            tableConstraints=[
+                # Malformed: two columns, one referred column — no join derivable.
+                CatalogConstraint(constraintType="FOREIGN_KEY", columns=["c", "d"], referredColumns=["broken.x"]),
+                # Usable: anchored on `c`, folding in `a`.
+                CatalogConstraint(
+                    constraintType="FOREIGN_KEY", columns=["c", "a"], referredColumns=["good.px", "good.py"]
+                ),
+            ],
+        )
+        good = CatalogTable(
+            id="2",
+            name="good",
+            fullyQualifiedName="s.good",
+            columns=[CatalogColumn(name=n, dataType="INT") for n in ("px", "py")],
+            tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=["px", "py"])],
+        )
+        return [child, good]
+
+    def test_the_usable_relationship_survives(self, strategy):
+        g = _build(strategy, self._tables())
+        ns = Namespace(PREFIX)
+        pom = ns["TriplesMap_Child/POM_C"]
+
+        assert _object_map_parent_tmap(g, pom) == ns.TriplesMap_Good
+        assert _object_map_join_conditions(g, pom) == [('"a"', '"py"'), ('"c"', '"px"')]
+
+    def test_the_anchor_is_not_degraded_to_a_literal(self, strategy):
+        g = _build(strategy, self._tables())
+        ns = Namespace(PREFIX)
+        pom = ns["TriplesMap_Child/POM_C"]
+
+        assert _object_map_datatype(g, pom) is None
+        assert _object_map_column(g, pom) is None
+
+    def test_a_column_only_in_the_malformed_fk_still_degrades(self, strategy):
+        """The malformed constraint is still unmappable — `d` must stay a literal."""
+        g = _build(strategy, self._tables())
+        ns = Namespace(PREFIX)
+        pom = ns["TriplesMap_Child/POM_D"]
+
+        assert _object_map_column(g, pom) == '"d"'
+        assert _object_map_parent_tmap(g, pom) is None
+
+    def test_range_and_datatype_do_not_contradict(self, strategy):
+        """The invariant that actually broke: rdfs:range vs rr:datatype."""
+        tables = self._tables()
+        onto, novel = strategy._build_proposal_ontology(PREFIX, tables, [])
+        r2rml = strategy.build_r2rml(PREFIX, tables, novel, onto)
+        ns = Namespace(PREFIX)
+
+        # The ontology declares an object property pointing at the USABLE FK's
+        # parent — not at `broken`, which the first-matching-constraint lookup used
+        # to return because the malformed constraint is listed first.
+        assert (ns.child_c, RDF.type, OWL.ObjectProperty) in onto
+        assert onto.value(ns.child_c, RDFS.range) == ns.Good
+
+        # And the mapping agrees: a referencing object map, no rr:datatype.
+        pom = ns["TriplesMap_Child/POM_C"]
+        assert _object_map_parent_tmap(r2rml, pom) == ns.TriplesMap_Good
+        assert _object_map_datatype(r2rml, pom) is None
+
+        # `d` is a literal in both artifacts.
+        assert (ns.child_d, RDF.type, OWL.DatatypeProperty) in onto
+        assert _object_map_datatype(r2rml, ns["TriplesMap_Child/POM_D"]) == XSD.integer
+
+    def test_every_declared_property_is_still_mapped(self, strategy):
+        tables = self._tables()
+        onto, novel = strategy._build_proposal_ontology(PREFIX, tables, [])
+        r2rml = strategy.build_r2rml(PREFIX, tables, novel, onto)
+
+        declared = {str(p) for p in onto.subjects(RDF.type, OWL.ObjectProperty)} | {
+            str(p) for p in onto.subjects(RDF.type, OWL.DatatypeProperty)
+        }
+        mapped = {str(p) for _, _, p in r2rml.triples((None, RR.predicate, None))}
+        assert declared - mapped == set()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# SECTION 14: Same table name in two databases
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestSameNameInDifferentDatabases:
+    """Two tables sharing a bare name are two tables.
+
+    One induction flattens every database of every requested datasource into a
+    single list (``_catalog_to_tables`` fills ``name`` from the bare table name and
+    puts the qualified form in ``fullyQualifiedName``), so ``public.customers`` and
+    ``analytics.customers`` arrive as two entries both named ``customers``. Keying
+    the local-name helper on the NAME collapsed them: one TriplesMap with two
+    ``rr:logicalTable`` / ``rr:tableName`` values — invalid R2RML, the same defect
+    the separator/case collisions produced, reached by a different route.
+    """
+
+    @staticmethod
+    def _tables():
+        return [
+            CatalogTable(
+                id=f"{schema}.customers",
+                name="customers",
+                fullyQualifiedName=f"{schema}.customers",
+                sourceSchema=schema,
+                columns=[CatalogColumn(name="id", dataType="INT")],
+                tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=["id"])],
+            )
+            for schema in ("public", "analytics")
+        ]
+
+    def test_two_triples_maps(self, strategy):
+        g = _build(strategy, self._tables())
+
+        assert len(set(g.subjects(RDF.type, RR.TriplesMap))) == 2
+
+    def test_each_triples_map_has_exactly_one_table_name(self, strategy):
+        """The R2RML invariant (§2.2: a TriplesMap has one logical table)."""
+        g = _build(strategy, self._tables())
+
+        for tmap in g.subjects(RDF.type, RR.TriplesMap):
+            logical_tables = list(g.objects(tmap, RR.logicalTable))
+            assert len(logical_tables) == 1, f"{tmap} has {len(logical_tables)} logical tables"
+            names = [str(n) for lt in logical_tables for n in g.objects(lt, RR.tableName)]
+            assert len(names) == 1, f"{tmap} maps {len(names)} tables: {names}"
+
+    def test_two_classes(self, strategy):
+        tables = self._tables()
+        onto, _ = strategy._build_proposal_ontology(PREFIX, tables, [])
+
+        classes = {str(c) for c in onto.subjects(RDF.type, OWL.Class)}
+        assert len([c for c in classes if "Customers" in c]) == 2, classes
+
+    def test_the_ontology_and_the_mapping_name_the_same_classes(self, strategy):
+        tables = self._tables()
+        onto, novel = strategy._build_proposal_ontology(PREFIX, tables, [])
+        r2rml = strategy.build_r2rml(PREFIX, tables, novel, onto)
+
+        declared = {str(c) for c in onto.subjects(RDF.type, OWL.Class)}
+        mapped = {str(c) for _, _, c in r2rml.triples((None, RR["class"], None))}
+        assert mapped <= declared, mapped - declared
+
+    def test_an_fk_resolves_within_its_own_schema(self, strategy):
+        """An ambiguous bare target must not join to the other database's table."""
+        tables = self._tables()
+        tables.append(
+            CatalogTable(
+                id="public.orders",
+                name="orders",
+                fullyQualifiedName="public.orders",
+                sourceSchema="public",
+                columns=[CatalogColumn(name="customer_id", dataType="INT")],
+                tableConstraints=[
+                    CatalogConstraint(
+                        constraintType="FOREIGN_KEY", columns=["customer_id"], referredColumns=["customers.id"]
+                    )
+                ],
+            )
+        )
+        g = _build(strategy, tables)
+        ns = Namespace(PREFIX)
+
+        parent = _object_map_parent_tmap(g, ns["TriplesMap_Orders/POM_CustomerId"])
+        assert parent is not None
+        assert str(parent).startswith(f"{PREFIX}TriplesMap_Customers")
+        # The FK must follow the referrer's own schema, not whichever same-named
+        # table happens to be reachable by bare name.
+        parent_schema = g.value(parent, SCL.sourceSchema)
+        assert str(parent_schema) == "public", f"FK left its own schema: {parent_schema}"
+
+    def test_a_unique_bare_name_still_resolves(self, strategy):
+        """The bare-name path must keep working when there is no ambiguity."""
+        tables = [
+            CatalogTable(
+                id="public.customers",
+                name="customers",
+                fullyQualifiedName="public.customers",
+                sourceSchema="public",
+                columns=[CatalogColumn(name="id", dataType="INT")],
+                tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=["id"])],
+            ),
+            CatalogTable(
+                id="analytics.orders",
+                name="orders",
+                fullyQualifiedName="analytics.orders",
+                sourceSchema="analytics",
+                columns=[CatalogColumn(name="customer_id", dataType="INT")],
+                tableConstraints=[
+                    CatalogConstraint(
+                        constraintType="FOREIGN_KEY", columns=["customer_id"], referredColumns=["customers.id"]
+                    )
+                ],
+            ),
+        ]
+        g = _build(strategy, tables)
+        ns = Namespace(PREFIX)
+
+        # Cross-schema, but unambiguous: resolve it rather than dropping the join.
+        assert _object_map_parent_tmap(g, ns["TriplesMap_Orders/POM_CustomerId"]) == ns.TriplesMap_Customers
+
+    def test_a_single_table_keeps_its_bare_iri(self, strategy):
+        """IRI stability: qualifying the identity must not change the local name."""
+        tables = [
+            CatalogTable(
+                id="public.customers",
+                name="customers",
+                fullyQualifiedName="public.customers",
+                sourceSchema="public",
+                columns=[CatalogColumn(name="id", dataType="INT")],
+                tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=["id"])],
+            )
+        ]
+        g = _build(strategy, tables)
+        ns = Namespace(PREFIX)
+
+        assert (ns.TriplesMap_Customers, RDF.type, RR.TriplesMap) in g

--- a/packages/ontology-engine/tests/unit/test_r2rml_spec_compliance.py
+++ b/packages/ontology-engine/tests/unit/test_r2rml_spec_compliance.py
@@ -25,7 +25,7 @@ from coa_ontology.inducer.services.data_catalog import (
     CatalogTable,
 )
 from coa_ontology.inducer.strategies.base import RR, SCL
-from rdflib import RDF, XSD, Graph, Namespace
+from rdflib import OWL, RDF, RDFS, XSD, Graph, Namespace, URIRef
 
 pytestmark = pytest.mark.unit
 
@@ -1995,3 +1995,157 @@ class TestEdgeCases:
         # First FK constraint wins — parentTriplesMap points to table_a
         parent = _object_map_parent_tmap(g, ns["TriplesMap_Refs/POM_TargetId"])
         assert parent == ns.TriplesMap_TableA
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# SECTION 10: IRI collision resolution (to_pascal is lossy)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+class TestPascalCaseCollisions:
+    """Distinct tables must never share a class / TriplesMap IRI.
+
+    ``to_pascal`` folds separators and case, so names like ``order_item`` and
+    ``order-item`` collapse onto one local name. Minting IRIs from it directly
+    fused the two tables: one TriplesMap carrying two ``rr:tableName`` values
+    (invalid R2RML — a TriplesMap has exactly one logical table) and one class
+    carrying both tables' labels and key axioms.
+    """
+
+    @staticmethod
+    def _tables(*names):
+        return [
+            CatalogTable(
+                id=str(i),
+                name=name,
+                fullyQualifiedName=f"db.{name}",
+                columns=[CatalogColumn(name="id", dataType="INT")],
+                tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=["id"])],
+            )
+            for i, name in enumerate(names, start=1)
+        ]
+
+    def test_separator_variants_get_distinct_triples_maps(self, strategy):
+        tables = self._tables("order_item", "order-item")
+        g = _build(strategy, tables)
+
+        tmaps = set(g.subjects(RDF.type, RR.TriplesMap))
+        assert len(tmaps) == 2, f"Expected one TriplesMap per table, got {tmaps}"
+
+    def test_each_triples_map_has_exactly_one_table_name(self, strategy):
+        """The R2RML invariant that the collision broke."""
+        tables = self._tables("order_item", "order-item")
+        g = _build(strategy, tables)
+
+        for tmap in g.subjects(RDF.type, RR.TriplesMap):
+            logical_tables = list(g.objects(tmap, RR.logicalTable))
+            assert len(logical_tables) == 1, f"{tmap} has {len(logical_tables)} logical tables"
+            names = [str(n) for lt in logical_tables for n in g.objects(lt, RR.tableName)]
+            assert len(names) == 1, f"{tmap} maps {len(names)} tables: {names}"
+
+    def test_both_source_tables_are_mapped(self, strategy):
+        """Neither table may be silently dropped by the disambiguation."""
+        tables = self._tables("order_item", "order-item")
+        g = _build(strategy, tables)
+
+        mapped = {
+            str(n)
+            for tmap in g.subjects(RDF.type, RR.TriplesMap)
+            for lt in g.objects(tmap, RR.logicalTable)
+            for n in g.objects(lt, RR.tableName)
+        }
+        assert mapped == {'"order_item"', '"order-item"'}
+
+    def test_case_only_variants_get_distinct_triples_maps(self, strategy):
+        tables = self._tables("Customer", "customer")
+        g = _build(strategy, tables)
+
+        assert len(set(g.subjects(RDF.type, RR.TriplesMap))) == 2
+
+    def test_non_colliding_names_keep_bare_pascal_iris(self, strategy):
+        """No discriminator when there is nothing to disambiguate (IRI stability)."""
+        tables = self._tables("orders", "customers")
+        g = _build(strategy, tables)
+        ns = Namespace(PREFIX)
+
+        assert (ns.TriplesMap_Orders, RDF.type, RR.TriplesMap) in g
+        assert (ns.TriplesMap_Customers, RDF.type, RR.TriplesMap) in g
+
+    def test_first_colliding_table_keeps_the_bare_iri(self, strategy):
+        """Existing deployments keep byte-identical IRIs for the first name."""
+        tables = self._tables("order_item", "order-item")
+        g = _build(strategy, tables)
+        ns = Namespace(PREFIX)
+
+        assert (ns.TriplesMap_OrderItem, RDF.type, RR.TriplesMap) in g
+        names = [
+            str(n) for lt in g.objects(ns.TriplesMap_OrderItem, RR.logicalTable) for n in g.objects(lt, RR.tableName)
+        ]
+        assert names == ['"order_item"']
+
+    def test_assignment_is_deterministic_across_runs(self, strategy):
+        """Same input order must mint the same IRIs every time."""
+        first = _build(strategy, self._tables("order_item", "order-item"))
+        second = _build(strategy, self._tables("order_item", "order-item"))
+
+        assert set(first.subjects(RDF.type, RR.TriplesMap)) == set(second.subjects(RDF.type, RR.TriplesMap))
+
+    def test_ontology_and_r2rml_agree_on_class_iris(self, strategy):
+        """The two builders must mint identical class IRIs for colliding names."""
+        tables = self._tables("order_item", "order-item")
+        onto, novel = strategy._build_proposal_ontology(PREFIX, tables, [])
+        r2rml = strategy.build_r2rml(PREFIX, tables, novel, onto)
+
+        onto_classes = set(onto.subjects(RDF.type, OWL.Class))
+        r2rml_classes = {c for _, _, c in r2rml.triples((None, RR["class"], None))}
+        assert r2rml_classes <= onto_classes, (
+            f"R2RML references classes absent from the ontology: {r2rml_classes - onto_classes}"
+        )
+        assert len(r2rml_classes) == 2
+
+    def test_ontology_gives_each_table_its_own_class_and_label(self, strategy):
+        tables = self._tables("order_item", "order-item")
+        onto, _ = strategy._build_proposal_ontology(PREFIX, tables, [])
+
+        labels_by_class = {
+            str(cls): sorted(str(lbl) for lbl in onto.objects(cls, RDFS.label))
+            for cls in onto.subjects(RDF.type, OWL.Class)
+        }
+        assert len(labels_by_class) == 2
+        for cls, labels in labels_by_class.items():
+            assert len(labels) == 1, f"{cls} carries labels from multiple tables: {labels}"
+
+    def test_colliding_tables_get_distinct_property_iris(self, strategy):
+        """Discriminated classes must carry discriminated property IRIs too."""
+        tables = [
+            CatalogTable(
+                id="1",
+                name="order_item",
+                fullyQualifiedName="db.order_item",
+                columns=[CatalogColumn(name="qty", dataType="INT")],
+            ),
+            CatalogTable(
+                id="2",
+                name="order-item",
+                fullyQualifiedName="db.order-item",
+                columns=[CatalogColumn(name="qty", dataType="INT")],
+            ),
+        ]
+        g = _build(strategy, tables)
+
+        predicates = {str(p) for _, _, p in g.triples((None, RR.predicate, None))}
+        assert len(predicates) == 2, f"Property IRIs still collide: {predicates}"
+
+    def test_shacl_config_agrees_with_ontology_class_iris(self, strategy):
+        """generate_config_from_db must target the classes the ontology declares."""
+        from coa_ontology.validation.shapes.config import generate_config_from_db
+
+        tables = self._tables("order_item", "order-item")
+        onto, _ = strategy._build_proposal_ontology(PREFIX, tables, [])
+        config = generate_config_from_db(tables, PREFIX)
+
+        onto_classes = set(onto.subjects(RDF.type, OWL.Class))
+        shape_classes = {URIRef(c.class_uri) for c in config.classes}
+        assert shape_classes <= onto_classes, f"Shapes target absent classes: {shape_classes - onto_classes}"
+        assert len(shape_classes) == 2

--- a/packages/ontology-engine/tests/unit/test_r2rml_spec_compliance.py
+++ b/packages/ontology-engine/tests/unit/test_r2rml_spec_compliance.py
@@ -943,14 +943,14 @@ class TestForeignKeyObjectMaps:
         col = _object_map_column(g, ns["TriplesMap_Invoices/POM_OrderRef"])
         assert col == '"order_ref"'
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Three-part referredColumns ('schema.table.column') extracts schema as target — not supported",
-    )
     def test_referred_columns_three_part_schema_table_column(self, strategy):
-        """Future-proofing: referredColumns as 'schema.table.column'.
-        parts[0] extracts 'schema' — this is WRONG. The correct target is parts[1]
-        (the table name). Marked xfail so a future fix auto-promotes."""
+        """referredColumns as 'schema.table.column' resolves to the TABLE, not the schema.
+
+        Was xfail: the R2RML builder took ``parts[0]`` (the schema) while the
+        ontology, the SHACL config, and the subtype detector all took
+        ``parts[-2]`` (the table), so the mapping pointed at a TriplesMap that does
+        not exist. All six call sites now share ``parse_referred_column``.
+        """
         tables = [
             CatalogTable(
                 id="1",
@@ -2355,3 +2355,155 @@ class TestOntologyR2rmlParity:
         onto, r2rml = self._both(strategy, tables)
 
         assert self._declared_properties(onto) - self._mapped_predicates(r2rml) == set()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# SECTION 12: referredColumns parsing is one shared rule
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+class TestReferredColumnParsing:
+    """All consumers must resolve an FK target identically.
+
+    The rule was re-implemented at six call sites under two incompatible
+    conventions: `parts[0]` in the R2RML builder and the RIGOR topological sort,
+    `parts[-2]` in the ontology builder, the SHACL config, the subtype detector,
+    and the fingerprint normalizer. For `schema.table.column` the former yields
+    the SCHEMA, so the mapping referenced a nonexistent TriplesMap while the
+    ontology and shapes correctly referenced the table.
+    """
+
+    @pytest.mark.parametrize(
+        ("ref", "expected"),
+        [
+            ("orders.order_id", ("orders", "order_id")),
+            ("public.orders.order_id", ("orders", "order_id")),
+            ("db.public.orders.order_id", ("orders", "order_id")),
+            ("orders", ("orders", None)),
+        ],
+    )
+    def test_parser_keeps_the_trailing_table_and_column(self, ref, expected):
+        from coa_ontology.inducer.services.data_catalog import parse_referred_column
+
+        assert parse_referred_column(ref) == expected
+
+    @staticmethod
+    def _schema_qualified_tables():
+        return [
+            CatalogTable(
+                id="1",
+                name="invoices",
+                fullyQualifiedName="billing.invoices",
+                columns=[CatalogColumn(name="order_ref", dataType="INT")],
+                tableConstraints=[
+                    CatalogConstraint(
+                        constraintType="FOREIGN_KEY",
+                        columns=["order_ref"],
+                        referredColumns=["public.orders.order_id"],
+                    )
+                ],
+            ),
+            CatalogTable(
+                id="2",
+                name="orders",
+                fullyQualifiedName="public.orders",
+                columns=[CatalogColumn(name="order_id", dataType="INT")],
+                tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=["order_id"])],
+            ),
+        ]
+
+    def test_r2rml_and_ontology_agree_on_a_schema_qualified_target(self, strategy):
+        tables = self._schema_qualified_tables()
+        onto, novel = strategy._build_proposal_ontology(PREFIX, tables, [])
+        r2rml = strategy.build_r2rml(PREFIX, tables, novel, onto)
+        ns = Namespace(PREFIX)
+
+        # Ontology: range is the TABLE's class, never a class named after the schema
+        assert onto.value(ns.invoices_orderRef, RDFS.range) == ns.Orders
+        # R2RML: parent is the TABLE's TriplesMap
+        parent = _object_map_parent_tmap(r2rml, ns["TriplesMap_Invoices/POM_OrderRef"])
+        assert parent == ns.TriplesMap_Orders
+
+    def test_shacl_config_agrees_on_a_schema_qualified_target(self, strategy):
+        from coa_ontology.validation.shapes.config import generate_config_from_db
+
+        config = generate_config_from_db(self._schema_qualified_tables(), PREFIX)
+
+        targets = [
+            c.params.get("target_class")
+            for cls in config.classes
+            for c in cls.constraints
+            if c.params and "target_class" in c.params
+        ]
+        assert targets == [f"{PREFIX}Orders"]
+
+    def test_no_class_is_minted_from_the_schema_name(self, strategy):
+        tables = self._schema_qualified_tables()
+        onto, _ = strategy._build_proposal_ontology(PREFIX, tables, [])
+
+        classes = {str(c) for c in onto.subjects(RDF.type, OWL.Class)}
+        assert f"{PREFIX}Public" not in classes
+
+    def test_join_condition_uses_the_trailing_column(self, strategy):
+        tables = self._schema_qualified_tables()
+        g = _build(strategy, tables)
+        ns = Namespace(PREFIX)
+
+        conditions = _object_map_join_conditions(g, ns["TriplesMap_Invoices/POM_OrderRef"])
+        assert conditions == [('"order_ref"', '"order_id"')]
+
+    def test_fingerprint_treats_qualified_and_bare_refs_as_equal(self):
+        """A rescan reporting a longer qualification must not look like a new schema."""
+        from coa_ontology.induce_catalog import _compute_structural_fingerprint
+
+        def _tables(ref):
+            return [
+                CatalogTable(
+                    id="1",
+                    name="invoices",
+                    fullyQualifiedName="billing.invoices",
+                    columns=[CatalogColumn(name="order_ref", dataType="INT")],
+                    tableConstraints=[
+                        CatalogConstraint(constraintType="FOREIGN_KEY", columns=["order_ref"], referredColumns=[ref])
+                    ],
+                )
+            ]
+
+        bare = _compute_structural_fingerprint(_tables("orders.order_id"))
+        qualified = _compute_structural_fingerprint(_tables("db.public.orders.order_id"))
+        assert bare == qualified
+
+    def test_subtype_detection_handles_a_schema_qualified_self_reference(self):
+        """PK-sharing detection must resolve the parent table, not the schema."""
+        from coa_ontology.inducer.services.subtype_detection import detect_pk_sharing_subtypes
+
+        parent = CatalogTable(
+            id="1",
+            name="claim_amount",
+            fullyQualifiedName="ins.claim_amount",
+            columns=[CatalogColumn(name="claim_id", dataType="INT")],
+            tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=["claim_id"])],
+        )
+        children = [
+            CatalogTable(
+                id=str(i + 2),
+                name=name,
+                fullyQualifiedName=f"ins.{name}",
+                columns=[CatalogColumn(name="claim_id", dataType="INT")],
+                tableConstraints=[
+                    CatalogConstraint(constraintType="PRIMARY_KEY", columns=["claim_id"]),
+                    CatalogConstraint(
+                        constraintType="FOREIGN_KEY",
+                        columns=["claim_id"],
+                        referredColumns=["ins.claim_amount.claim_id"],
+                    ),
+                ],
+            )
+            for i, name in enumerate(("loss_payment", "expense_payment"))
+        ]
+
+        confirmed, _suggested = detect_pk_sharing_subtypes([parent, *children])
+
+        assert ("loss_payment", "claim_amount") in confirmed
+        assert ("expense_payment", "claim_amount") in confirmed

--- a/packages/sources/src/coa_sources/database/bulk_review/worker.py
+++ b/packages/sources/src/coa_sources/database/bulk_review/worker.py
@@ -342,6 +342,74 @@ def _verify_in_transient(
     return bool(item and item.get("status") == expected_transient)
 
 
+def _rejected_key_column_reason(assets: list[dict[str, Any]], source_id: str) -> str | None:
+    """Return a denial reason if an approved table would ship without its key columns.
+
+    Runs AFTER the cascade, which is fine — and necessary — because the condition
+    it tests is one the cascade cannot manufacture: a bulk APPROVE never turns a
+    column REJECTED (it flips only ``PENDING_REVIEW`` → ``APPROVED`` and
+    deliberately preserves explicit REJECTED decisions, see
+    ``coa_common.review_logic``). So a REJECTED key column here was rejected by a
+    human, and survives the cascade untouched.
+
+    Why this is the condition that matters: ``catalog_reader`` projects only
+    ``APPROVED`` columns into the induction payload
+    (``_table_to_induction_format``). A REJECTED primary-key column therefore
+    disappears from the catalog while the table itself is APPROVED, and induction
+    mints a subject template with no key to build from — surfacing later as a
+    PK-column-missing error in Ontop, far from the review that caused it. A
+    REJECTED foreign-key column silently drops the relationship instead, so the
+    ontology loses an object property the schema does have.
+
+    This replaces a gate that looked for ``PENDING_REVIEW`` columns *after* the
+    cascade had already flipped every one of them to ``APPROVED`` — structurally
+    unreachable dead code. Checking pending columns pre-cascade is not the fix
+    either: the enricher leaves ALL columns ``PENDING_REVIEW``
+    (``table_enricher.py``), and clearing them is precisely what bulk approve is
+    for, so blocking on pending would reject every normal bulk approval.
+
+    Args:
+        assets: Loaded assets for this page, post-cascade.
+        source_id: Source id, for logging.
+
+    Returns:
+        A human-readable reason when the approval must be blocked, else ``None``.
+    """
+    offenders: list[tuple[str, str, str]] = []  # (table, column, key kind)
+    for asset in assets:
+        table = asset["table"]
+        if table.business_metadata.review_status != ReviewStatus.APPROVED:
+            continue  # not shipping, so its column states are moot
+
+        key_kinds: dict[str, str] = {}
+        for pk_col in table.primary_key.columns or []:
+            key_kinds[pk_col] = "primary key"
+        for fk in table.foreign_keys or []:
+            if fk.column and fk.column not in key_kinds:
+                key_kinds[fk.column] = "foreign key"
+
+        for col in table.columns:
+            kind = key_kinds.get(col.name)
+            if kind and col.business_metadata.review_status == ReviewStatus.REJECTED:
+                offenders.append((table.name, col.name, kind))
+
+    if not offenders:
+        return None
+
+    sample = offenders[:10]
+    logger.warning(
+        "bulk_approve_blocked_rejected_key_columns",
+        extra={"source_id": source_id, "rejected_key_count": len(offenders), "sample": sample},
+    )
+    return (
+        f"Cannot approve: {len(offenders)} key column(s) across "
+        f"{len({t for t, _, _ in offenders})} table(s) are REJECTED, but their tables are approved. "
+        "A rejected key column is dropped from the induction catalog, leaving the table without a "
+        "usable key. Un-reject these columns or reject the whole table. Examples: "
+        + ", ".join(f"{t}.{c} ({kind})" for t, c, kind in sample)
+    )
+
+
 def process_bulk_review(
     *,
     msg: BulkReviewMessage,
@@ -432,36 +500,12 @@ def process_bulk_review(
     # Fold in the count accumulated by earlier pages in the chain.
     tables_approved = msg.tables_approved_so_far + tables_approved_this_page
 
-    # Gate: if approving, verify no column is left in PENDING_REVIEW after the
-    # cascade. Columns that the enricher couldn't auto-approve (structural/identity
-    # columns like PKs/FKs) would break downstream consumers (schema.sql generation
-    # filters to APPROVED-only columns, causing PK-column-missing errors in Ontop).
-    # Fail the approval with a clear message so the user reviews those columns first.
+    # Gate: refuse an approval that would ship a table whose PK/FK column is
+    # REJECTED. See _rejected_key_column_reason for why this is the condition
+    # that actually breaks downstream, and why the previous check could not fire.
     if msg.decision == ReviewDecision.APPROVED and not failed:
-        pending_cols: list[tuple[str, str]] = []
-        for asset in assets:
-            # Only check tables that are APPROVED — rejected/pending tables won't
-            # feed into induction/schema-generation, so their column states are moot.
-            if asset["table"].business_metadata.review_status != ReviewStatus.APPROVED:
-                continue
-            for col in asset["table"].columns:
-                if col.business_metadata.review_status == ReviewStatus.PENDING_REVIEW:
-                    pending_cols.append((asset["table"].name, col.name))
-        if pending_cols:
-            sample = pending_cols[:10]
-            reason = (
-                f"Cannot approve: {len(pending_cols)} column(s) across "
-                f"{len({t for t, _ in pending_cols})} table(s) are still PENDING_REVIEW. "
-                f"Review or approve these columns first. Examples: " + ", ".join(f"{t}.{c}" for t, c in sample)
-            )
-            logger.warning(
-                "bulk_approve_blocked_pending_columns",
-                extra={
-                    "source_id": msg.source_id,
-                    "pending_count": len(pending_cols),
-                    "sample": sample,
-                },
-            )
+        reason = _rejected_key_column_reason(assets, msg.source_id)
+        if reason is not None:
             failed.append(reason)
 
     # More assets remain AND this page had no failures → continue in a fresh

--- a/packages/sources/tests/unit/conftest.py
+++ b/packages/sources/tests/unit/conftest.py
@@ -3,13 +3,33 @@
 
 """Sources unit test configuration.
 
-Required by coa_common.response (lazy check at api_response() call
-time). Set before any handler imports so api_response() can return error
-responses; otherwise every handler test raises RuntimeError("ALLOWED_ORIGIN
-environment variable must be set"). Matches the pattern used by control-plane
-and metric-service unit conftests.
+``ALLOWED_ORIGIN`` is required by coa_common.response (lazy check at
+api_response() call time). Set before any handler imports so api_response() can
+return error responses; otherwise every handler test raises
+RuntimeError("ALLOWED_ORIGIN environment variable must be set"). Matches the
+pattern used by control-plane and metric-service unit conftests.
+
+``AWS_REGION`` is pinned — not ``setdefault``-ed — because the handlers resolve
+their region via ``coa_common.resolve_region()``, which reads ``AWS_REGION``
+FIRST and only then falls back to ``AWS_DEFAULT_REGION``. The moto fixtures
+create their tables in us-east-1 and several test modules set only
+``AWS_DEFAULT_REGION``, so a developer (or CI runner) with ``AWS_REGION`` exported
+to anything else had the handler build its DAO against that region while the
+table lived in us-east-1 — every query failed with ResourceNotFoundException and
+the handler returned 500. That made ~10 tests fail depending on nothing but the
+shell they ran in.
 """
 
 import os
 
 os.environ.setdefault("ALLOWED_ORIGIN", "https://test.example.com")
+
+# Overwrite, don't setdefault: an inherited value is exactly the problem.
+os.environ["AWS_REGION"] = "us-east-1"
+os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+# moto rejects requests with no credentials; keep them obviously fake so a
+# misconfigured test can never reach real AWS.
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
+os.environ.setdefault("AWS_SECURITY_TOKEN", "testing")
+os.environ.setdefault("AWS_SESSION_TOKEN", "testing")

--- a/packages/sources/tests/unit/database/test_bulk_review_worker.py
+++ b/packages/sources/tests/unit/database/test_bulk_review_worker.py
@@ -29,6 +29,8 @@ import coa_sources.database.bulk_review.worker as worker  # noqa: E402
 from coa_common.domain_models import (  # noqa: E402
     BusinessMetadata,
     Column,
+    ForeignKey,
+    PrimaryKey,
     Table,
 )
 from coa_common.review_logic import apply_decision_to_table  # noqa: E402
@@ -745,3 +747,180 @@ class TestBulkReviewPaging:
             )
         assert result.tables_total == 0
         mock_client.search_assets.assert_not_called()
+
+
+# ===================================================================
+# Rejected key-column gate
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestRejectedKeyColumnGate:
+    """An approved table must not ship with a REJECTED primary/foreign key column.
+
+    `catalog_reader._table_to_induction_format` projects only APPROVED columns, so
+    a rejected PK vanishes from the induction catalog while its table stays
+    APPROVED — induction then has no key to build a subject template from and the
+    failure surfaces as a PK-column-missing error in Ontop, far from the review
+    that caused it.
+
+    This gate replaced one that scanned for PENDING_REVIEW columns *after* the
+    bulk cascade had already flipped every one of them to APPROVED (unreachable),
+    and which could not be moved pre-cascade either: the enricher leaves all
+    columns PENDING_REVIEW, so blocking on pending would reject every normal bulk
+    approval.
+    """
+
+    _DAO_PATCH = "coa_sources.database.bulk_review.worker.DynamoDBDAO"
+
+    @staticmethod
+    def _table_with_keys(
+        *,
+        table_name: str = "orders",
+        table_status: str = "APPROVED",
+        columns: list[tuple[str, str]],
+        pk_columns: list[str] | None = None,
+        fk_column: str | None = None,
+    ) -> Table:
+        return Table(
+            name=table_name,
+            database="db",
+            data_source_id=_SOURCE_ID,
+            namespace_id=_NAMESPACE_ID,
+            business_metadata=BusinessMetadata(review_status=table_status),
+            primary_key=PrimaryKey(columns=pk_columns or []),
+            foreign_keys=(
+                [ForeignKey(column=fk_column, target_table="other", target_column="id")] if fk_column else []
+            ),
+            columns=[
+                Column(name=name, data_type="string", business_metadata=BusinessMetadata(review_status=status))
+                for name, status in columns
+            ],
+        )
+
+    def _run(self, tables: list[Table]):
+        mock_dao = MagicMock()
+        mock_dao.get.return_value = {"status": "APPROVING"}
+        mock_client = _mock_smus_with_assets(tables)
+        with patch(self._DAO_PATCH, return_value=mock_dao):
+            return worker.process_bulk_review(
+                msg=worker.BulkReviewMessage(namespace_id=_NAMESPACE_ID, source_id=_SOURCE_ID, decision="APPROVED"),
+                client=mock_client,
+                project_id="proj-123",
+                sources_table="test-sources",
+                region="us-east-1",
+            )
+
+    def test_rejected_primary_key_column_blocks_approval(self):
+        result = self._run(
+            [
+                self._table_with_keys(
+                    columns=[("id", "REJECTED"), ("name", "APPROVED")],
+                    pk_columns=["id"],
+                )
+            ]
+        )
+        assert result.tables_failed, "approval should have been blocked"
+        assert "orders.id (primary key)" in result.tables_failed[0]
+
+    def test_rejected_foreign_key_column_blocks_approval(self):
+        result = self._run(
+            [
+                self._table_with_keys(
+                    columns=[("id", "APPROVED"), ("customer_id", "REJECTED")],
+                    pk_columns=["id"],
+                    fk_column="customer_id",
+                )
+            ]
+        )
+        assert result.tables_failed
+        assert "orders.customer_id (foreign key)" in result.tables_failed[0]
+
+    def test_rejected_non_key_column_does_not_block(self):
+        """Rejecting an ordinary column is a legitimate review decision."""
+        result = self._run(
+            [
+                self._table_with_keys(
+                    columns=[("id", "APPROVED"), ("notes", "REJECTED")],
+                    pk_columns=["id"],
+                )
+            ]
+        )
+        assert result.tables_failed == []
+
+    def test_all_approved_keys_do_not_block(self):
+        result = self._run(
+            [
+                self._table_with_keys(
+                    columns=[("id", "APPROVED"), ("customer_id", "APPROVED")],
+                    pk_columns=["id"],
+                    fk_column="customer_id",
+                )
+            ]
+        )
+        assert result.tables_failed == []
+
+    def test_pending_columns_do_not_block_the_normal_case(self):
+        """The regression the previous gate would have caused if moved pre-cascade.
+
+        The enricher leaves every column PENDING_REVIEW; clearing them is the
+        entire point of bulk approve.
+        """
+        result = self._run(
+            [
+                self._table_with_keys(
+                    table_status="PENDING_REVIEW",
+                    columns=[("id", "PENDING_REVIEW"), ("name", "PENDING_REVIEW")],
+                    pk_columns=["id"],
+                )
+            ]
+        )
+        assert result.tables_failed == []
+        assert result.tables_changed == 1
+
+    def test_rejected_key_on_a_rejected_table_does_not_block(self):
+        """A table that is not shipping cannot break induction."""
+        result = self._run(
+            [
+                self._table_with_keys(
+                    table_status="REJECTED",
+                    columns=[("id", "REJECTED")],
+                    pk_columns=["id"],
+                )
+            ]
+        )
+        assert result.tables_failed == []
+
+    def test_composite_primary_key_partially_rejected_blocks(self):
+        result = self._run(
+            [
+                self._table_with_keys(
+                    columns=[("day", "APPROVED"), ("hour", "REJECTED")],
+                    pk_columns=["day", "hour"],
+                )
+            ]
+        )
+        assert result.tables_failed
+        assert "orders.hour (primary key)" in result.tables_failed[0]
+
+    def test_reject_decision_never_runs_the_gate(self):
+        """The gate guards approvals only; a bulk REJECT is always allowed."""
+        mock_dao = MagicMock()
+        mock_dao.get.return_value = {"status": "REJECTING"}
+        tables = [
+            self._table_with_keys(
+                table_status="APPROVED",
+                columns=[("id", "REJECTED")],
+                pk_columns=["id"],
+            )
+        ]
+        mock_client = _mock_smus_with_assets(tables)
+        with patch(self._DAO_PATCH, return_value=mock_dao):
+            result = worker.process_bulk_review(
+                msg=worker.BulkReviewMessage(namespace_id=_NAMESPACE_ID, source_id=_SOURCE_ID, decision="REJECTED"),
+                client=mock_client,
+                project_id="proj-123",
+                sources_table="test-sources",
+                region="us-east-1",
+            )
+        assert result.tables_failed == []

--- a/scripts/deploy-serve.sh
+++ b/scripts/deploy-serve.sh
@@ -22,7 +22,11 @@ set -euo pipefail
 #   IMAGE_TAG=v1.2.3 ./scripts/deploy-serve.sh
 
 ENV="${1:-dev}"
-PREFIX="${SCL_PREFIX:-scl}"
+# Default MUST match the CDK app's DEFAULT_RESOURCE_PREFIX
+# (libs/ts-shared/src/constants.ts, resolved in infra/lib/context.ts).
+# A mismatch means this script resolves scl-* names / /scl SSM parameters
+# while `cdk` operates on coa-* — every lookup silently misses.
+PREFIX="${SCL_PREFIX:-coa}"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 ECR_REPO="${PREFIX}-${ENV}-context-manager"
@@ -105,32 +109,47 @@ RUNTIME_ARN=$(aws cloudformation describe-stacks \
   --query 'Stacks[0].Outputs[?OutputKey==`AgentRuntimeArn`].OutputValue' \
   --output text 2>/dev/null || echo "")
 
-ENDPOINT_NAME=$(aws cloudformation describe-stacks \
-  --stack-name "${PREFIX}-${ENV}-serve" \
-  --query 'Stacks[0].Outputs[?OutputKey==`AgentRuntimeEndpointName`].OutputValue' \
-  --output text 2>/dev/null || echo "")
+# The serve stack exports AgentRuntimeArn / AgentRuntimeId / AgentRuntimeName —
+# there is no AgentRuntimeEndpointName output. Reading it always yielded an empty
+# qualifier, and because every failure below was redirected to /dev/null the smoke
+# test "passed" while verifying nothing. DEFAULT is the qualifier AgentCore
+# creates alongside a runtime.
+ENDPOINT_NAME="${AGENT_RUNTIME_QUALIFIER:-DEFAULT}"
 
-if [ -n "${RUNTIME_ARN}" ] && [ "${RUNTIME_ARN}" != "None" ]; then
-  HEALTH_PAYLOAD=$(mktemp)
-  RESPONSE_FILE=$(mktemp)
-  echo '{"query":"ping","namespace":"smoke-test"}' > "${HEALTH_PAYLOAD}"
+if [ -z "${RUNTIME_ARN}" ] || [ "${RUNTIME_ARN}" = "None" ]; then
+  echo "  FAILED: stack ${PREFIX}-${ENV}-serve has no AgentRuntimeArn output" >&2
+  exit 1
+fi
 
-  # Allow warm-up time — retry up to 3 times
-  for attempt in 1 2 3; do
-    if aws bedrock-agentcore invoke-agent-runtime \
-      --agent-runtime-arn "${RUNTIME_ARN}" \
-      --qualifier "${ENDPOINT_NAME}" \
-      --content-type "application/json" \
-      --payload "fileb://${HEALTH_PAYLOAD}" \
-      "${RESPONSE_FILE}" > /dev/null 2>&1; then
-      echo "  Health: $(cat "${RESPONSE_FILE}")"
-      break
-    fi
-    [ "${attempt}" -lt 3 ] && sleep 10
-  done
-  rm -f "${HEALTH_PAYLOAD}" "${RESPONSE_FILE}"
-else
-  echo "  Skipped (no AgentRuntimeArn output)"
+HEALTH_PAYLOAD=$(mktemp)
+RESPONSE_FILE=$(mktemp)
+INVOKE_LOG=$(mktemp)
+echo '{"query":"ping","namespace":"smoke-test"}' > "${HEALTH_PAYLOAD}"
+
+SMOKE_OK=0
+# Allow warm-up time — retry up to 3 times
+for attempt in 1 2 3; do
+  if aws bedrock-agentcore invoke-agent-runtime \
+    --agent-runtime-arn "${RUNTIME_ARN}" \
+    --qualifier "${ENDPOINT_NAME}" \
+    --content-type "application/json" \
+    --payload "fileb://${HEALTH_PAYLOAD}" \
+    "${RESPONSE_FILE}" > "${INVOKE_LOG}" 2>&1; then
+    echo "  Health: $(cat "${RESPONSE_FILE}")"
+    SMOKE_OK=1
+    break
+  fi
+  echo "  attempt ${attempt}/3 failed: $(tail -n 3 "${INVOKE_LOG}")" >&2
+  [ "${attempt}" -lt 3 ] && sleep 10
+done
+
+rm -f "${HEALTH_PAYLOAD}" "${RESPONSE_FILE}" "${INVOKE_LOG}"
+
+# Fail loudly. A deploy script whose verification cannot fail is not a
+# verification.
+if [ "${SMOKE_OK}" -ne 1 ]; then
+  echo "  FAILED: smoke test could not invoke the runtime after 3 attempts" >&2
+  exit 1
 fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────

--- a/scripts/deploy-serve.sh
+++ b/scripts/deploy-serve.sh
@@ -99,58 +99,57 @@ pnpm --filter coa-infra exec cdk deploy "${PREFIX}-${ENV}-serve" \
   ${CONTEXT} \
   ${APPROVAL}
 
-# ── Smoke Test ───────────────────────────────────────────────────────────────
+# ── Post-deploy check ────────────────────────────────────────────────────────
+#
+# This deliberately does NOT invoke the runtime. The runtime is created with
+# `RuntimeAuthorizerConfiguration.usingJWT(...)` (serve-stack.ts), so it accepts
+# only a bearer ID token from the configured IdP — a SigV4
+# `aws bedrock-agentcore invoke-agent-runtime` is rejected no matter how long the
+# runtime has been warm. The previous version of this block appeared to invoke the
+# runtime but read a CFN output that does not exist (`AgentRuntimeEndpointName`,
+# while the stack exports AgentRuntimeArn / Id / Name), so the qualifier was always
+# empty and every failure was redirected to /dev/null — it "passed" while verifying
+# nothing.
+#
+# Rather than fake an invocation, assert what can actually be checked without a
+# user token: the runtime exists and reached a READY state. An end-to-end query
+# needs an ID token and belongs in the integ suite (`make test-integ`), not here.
 
 echo ""
-echo "--- Smoke test ---"
+echo "--- Post-deploy check ---"
 
 RUNTIME_ARN=$(aws cloudformation describe-stacks \
   --stack-name "${PREFIX}-${ENV}-serve" \
   --query 'Stacks[0].Outputs[?OutputKey==`AgentRuntimeArn`].OutputValue' \
   --output text 2>/dev/null || echo "")
 
-# The serve stack exports AgentRuntimeArn / AgentRuntimeId / AgentRuntimeName —
-# there is no AgentRuntimeEndpointName output. Reading it always yielded an empty
-# qualifier, and because every failure below was redirected to /dev/null the smoke
-# test "passed" while verifying nothing. DEFAULT is the qualifier AgentCore
-# creates alongside a runtime.
-ENDPOINT_NAME="${AGENT_RUNTIME_QUALIFIER:-DEFAULT}"
-
 if [ -z "${RUNTIME_ARN}" ] || [ "${RUNTIME_ARN}" = "None" ]; then
   echo "  FAILED: stack ${PREFIX}-${ENV}-serve has no AgentRuntimeArn output" >&2
   exit 1
 fi
+echo "  Runtime ARN: ${RUNTIME_ARN}"
 
-HEALTH_PAYLOAD=$(mktemp)
-RESPONSE_FILE=$(mktemp)
-INVOKE_LOG=$(mktemp)
-echo '{"query":"ping","namespace":"smoke-test"}' > "${HEALTH_PAYLOAD}"
-
-SMOKE_OK=0
-# Allow warm-up time — retry up to 3 times
+RUNTIME_ID="${RUNTIME_ARN##*/}"
+STATUS=""
 for attempt in 1 2 3; do
-  if aws bedrock-agentcore invoke-agent-runtime \
-    --agent-runtime-arn "${RUNTIME_ARN}" \
-    --qualifier "${ENDPOINT_NAME}" \
-    --content-type "application/json" \
-    --payload "fileb://${HEALTH_PAYLOAD}" \
-    "${RESPONSE_FILE}" > "${INVOKE_LOG}" 2>&1; then
-    echo "  Health: $(cat "${RESPONSE_FILE}")"
-    SMOKE_OK=1
-    break
-  fi
-  echo "  attempt ${attempt}/3 failed: $(tail -n 3 "${INVOKE_LOG}")" >&2
+  STATUS=$(aws bedrock-agentcore-control get-agent-runtime \
+    --agent-runtime-id "${RUNTIME_ID}" \
+    --query 'status' --output text 2>/dev/null || echo "")
+  case "${STATUS}" in
+    READY) break ;;
+    CREATING|UPDATING) echo "  status=${STATUS}, waiting..." ;;
+    "") echo "  could not read runtime status (attempt ${attempt}/3)" >&2 ;;
+    *) echo "  status=${STATUS}" >&2 ;;
+  esac
   [ "${attempt}" -lt 3 ] && sleep 10
 done
 
-rm -f "${HEALTH_PAYLOAD}" "${RESPONSE_FILE}" "${INVOKE_LOG}"
-
-# Fail loudly. A deploy script whose verification cannot fail is not a
-# verification.
-if [ "${SMOKE_OK}" -ne 1 ]; then
-  echo "  FAILED: smoke test could not invoke the runtime after 3 attempts" >&2
+if [ "${STATUS}" != "READY" ]; then
+  echo "  FAILED: runtime ${RUNTIME_ID} is '${STATUS:-unknown}', expected READY" >&2
+  echo "  (an end-to-end query needs an IdP token — see 'make test-integ')" >&2
   exit 1
 fi
+echo "  Runtime status: READY"
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 
@@ -160,14 +159,18 @@ echo "  Stack:    ${PREFIX}-${ENV}-serve"
 echo "  Image:    ${IMAGE_FULL}"
 if [ -n "${RUNTIME_ARN}" ] && [ "${RUNTIME_ARN}" != "None" ]; then
   echo "  Runtime:  ${RUNTIME_ARN}"
-  echo "  Endpoint: ${ENDPOINT_NAME}"
   echo ""
-  echo "Invoke with:"
-  echo "  echo '{\"query\":\"...\",\"namespace\":\"...\"}' > payload.json"
-  echo "  aws bedrock-agentcore invoke-agent-runtime \\"
-  echo "    --agent-runtime-arn '${RUNTIME_ARN}' \\"
-  echo "    --qualifier '${ENDPOINT_NAME}' \\"
-  echo "    --content-type 'application/json' \\"
-  echo "    --payload 'fileb://payload.json' \\"
-  echo "    response.json"
+  # The runtime authorizes with JWT (serve-stack.ts), so it needs a bearer ID
+  # token from the configured IdP — a SigV4 `aws bedrock-agentcore
+  # invoke-agent-runtime` is rejected. The previous version of this block
+  # printed exactly that command, which cannot work.
+  echo "Invoke with a bearer ID token from the app's IdP:"
+  echo "  curl -X POST \\"
+  echo "    'https://bedrock-agentcore.${REGION}.amazonaws.com/runtimes/${RUNTIME_ID}/invocations?qualifier=DEFAULT' \\"
+  echo "    -H \"Authorization: Bearer \${ID_TOKEN}\" \\"
+  echo "    -H 'Content-Type: application/json' \\"
+  echo "    -d '{\"query\":\"...\",\"namespace\":\"...\"}'"
+  echo ""
+  echo "Or run the integ suite, which provisions a token for you:"
+  echo "  make test-integ"
 fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -26,7 +26,8 @@ CONTEXT="--context env=$ENV"
 [ -n "${SCL_HOSTED_ZONE_ID:-}" ] && CONTEXT="$CONTEXT --context hosted_zone_id=$SCL_HOSTED_ZONE_ID"
 
 # ── Resolve VPC peering context from test-databases stack (if deployed) ──
-TEST_STACK_NAME="${SCL_PREFIX:-scl}-integ-test-databases"
+# Prefix default matches the CDK app (see DEFAULT_RESOURCE_PREFIX).
+TEST_STACK_NAME="${SCL_PREFIX:-coa}-integ-test-databases"
 if [ -z "${SCL_JDBC_PEER_VPC_ID:-}" ]; then
   SCL_JDBC_PEER_VPC_ID=$(aws cloudformation describe-stacks \
     --stack-name "$TEST_STACK_NAME" \
@@ -43,6 +44,11 @@ if [ -n "${SCL_JDBC_PEER_VPC_ID:-}" ] && [ "$SCL_JDBC_PEER_VPC_ID" != "None" ] \
   && [ -n "${SCL_JDBC_PEER_CIDRS:-}" ] && [ "$SCL_JDBC_PEER_CIDRS" != "None" ]; then
   echo "Peering into test VPC ${SCL_JDBC_PEER_VPC_ID} (${SCL_JDBC_PEER_CIDRS})"
   CONTEXT="$CONTEXT --context jdbc_peer_vpc_id=$SCL_JDBC_PEER_VPC_ID --context jdbc_peer_cidrs=$SCL_JDBC_PEER_CIDRS"
+else
+  # The stack is optional, so skipping is normal — but say so. Silence here is
+  # indistinguishable from a prefix mismatch resolving the wrong stack name, which
+  # is how this went unnoticed while the default was 'scl'.
+  echo "No JDBC peering context (stack ${TEST_STACK_NAME} not found or has no VPC outputs) — skipping"
 fi
 
 # ponytail: CDK_DOCKER selection — only pick Finch if its daemon is actually

--- a/scripts/destroy.sh
+++ b/scripts/destroy.sh
@@ -37,7 +37,11 @@ set -uo pipefail
 ENV="${1:-dev}"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 REGION="${CDK_DEFAULT_REGION:-${AWS_DEFAULT_REGION:-${AWS_REGION:-us-east-1}}}"
-PREFIX="${SCL_PREFIX:-scl}"
+# Default MUST match the CDK app's DEFAULT_RESOURCE_PREFIX
+# (libs/ts-shared/src/constants.ts, resolved in infra/lib/context.ts).
+# A mismatch means this script resolves scl-* names / /scl SSM parameters
+# while `cdk` operates on coa-* — every lookup silently misses.
+PREFIX="${SCL_PREFIX:-coa}"
 STACK_PREFIX="${PREFIX}-${ENV}"
 SSM_PREFIX="/${PREFIX}"
 

--- a/scripts/fetch-runtime-config.sh
+++ b/scripts/fetch-runtime-config.sh
@@ -12,7 +12,11 @@ set -euo pipefail
 
 REGION=""
 PROFILE=""
-PREFIX="scl"
+# Keep in sync with DEFAULT_RESOURCE_PREFIX in libs/ts-shared/src/constants.ts.
+# Defaulting to "scl" while the CDK app defaults to "coa" made this script read
+# outputs from a stack named scl-dev-* that a default deployment never creates,
+# so runtime-config.json came back empty instead of failing loudly.
+PREFIX="${SCL_PREFIX:-coa}"
 ENV="dev"
 
 while [[ $# -gt 0 ]]; do

--- a/scripts/onboard-demo.sh
+++ b/scripts/onboard-demo.sh
@@ -58,7 +58,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 PROFILE=""
 REGION="${AWS_DEFAULT_REGION:-us-west-2}"
-PREFIX="scl"
+# Keep in sync with DEFAULT_RESOURCE_PREFIX in libs/ts-shared/src/constants.ts.
+PREFIX="${SCL_PREFIX:-coa}"
 ENV_NAME="dev"
 INDUSTRY="insurance"
 MANIFEST=""              # explicit manifest path (else demo/$INDUSTRY/manifest.yaml)

--- a/scripts/serve/benchmark/runner.py
+++ b/scripts/serve/benchmark/runner.py
@@ -20,7 +20,7 @@ Usage:
 
 Environment:
     AWS_REGION       (default: us-east-1)
-    SCL_PREFIX       (default: scl)
+    SCL_PREFIX       (default: coa)
     SCL_USERNAME     Cognito username (default: from Secrets Manager)
     SCL_PASSWORD     Cognito password (default: from Secrets Manager)
     BENCH_NS         Namespace override


### PR DESCRIPTION
Every fix carries a regression test, and where the defect was observable I
verified it by running the code before and after rather than reasoning about it —
the commit messages record what was measured.

Fixes #6, fixes #7, fixes #8, fixes #9, fixes #10, fixes #11, fixes #12,
fixes #13, fixes #14, fixes #15, fixes #16, fixes #17, fixes #18.

> **The `Fixes #N` trailers inside the commits are wrong — ignore them.** They
> carry the issue numbering from my fork, where I triaged these first, so they
> point at unrelated closed PRs here (which is also why #1–#5 picked up stray
> cross-references). The keywords above and the table below are the authoritative
> mapping. Sorry for the noise.

## Why one PR

I tried to split this into five (tests / ontology / infra / authz / misc) and
abandoned it: the commits share files in a way that makes a mechanical split
unsafe. The infra test-isolation fix depends on the test file the LakeFormation
fix adds, and the four ontology fixes all touch `strategies/base.py` and the same
test module — the FK-parsing fix is what lets the composite-FK fix read a single
shared helper. Splitting would mean rewriting the fixes, which invites new bugs in
exchange for reviewability.

To keep it readable: **one commit per issue**, each with the defect, the evidence,
and the reasoning. Reviewing commit by commit should be close to reviewing separate
PRs.

## Behaviour changes — please read before merging

Three commits **narrow** authorization. They are correct, but they are not
invisible to existing deployments:

- **#17** — a user holding `platform-viewer` alongside a restricted namespace role
  currently sees every column; after this, their `columnDenylist` applies. Anyone
  relying on the current (accidental) behaviour will see columns disappear. This is
  the documented intent — `role-permission-management.md` states both layers must
  allow — but it is a visible change.
- **#18** — `resolve_profile` now propagates grant-lookup failures instead of
  degrading to a partial read. A transient DynamoDB error becomes a failed request
  rather than a silently widened one.
- The mcp-server admin fallback now fails closed. See #18's second section: the
  #18 fix is what makes that branch reachable, so shipping the pagination fix
  without it would make the system *less* safe.

Two more that change behaviour outside authorization, which I should have listed
from the start:

- **`destroy.sh` gains its teeth.** The #12 fix means the pre-`cdk destroy`
  cleanup — deleting AgentCore runtimes, deleting the VKG ECS service,
  force-deleting the DataZone domain — now actually resolves the default
  `coa-dev-*` stacks and runs. It has been silently no-op'ing on default
  deployments. That is the point of the fix, but it is the most destructive change
  here: anyone who has been running `destroy.sh` and relying on it leaving those
  resources alone will find it no longer does.
- **#13 keeps lexical forms byte-identical** (`normalize=False`), so a few values
  that previously "repaired" by being rewritten now stay put and are reported as
  `repairable: false` instead — `"TRUE"^^xsd:bool` is the case I hit. Trading
  repair rate for not mutating user data at a write boundary seemed right, but it
  is a judgement call and I would rather you saw it stated.

On #17, the blast radius is wider than the issue says: `authnz-stack.ts` seeds
every IdP-group→role mapping with `resourceId: "GLOBAL"`, so this dissolved
restrictions for ordinary users with a mapped group, not only for holders of a
platform role.

`#14` (IRI collisions) only affects NEW inductions. Existing accepted ontologies
keep their IRIs; the first name in a colliding set keeps the bare PascalCase form
specifically so unaffected schemas mint byte-identical IRIs.

## Commits

| # | Issue | Commit |
|---|---|---|
| 1 | #17 | `fix(serve): scope data-restriction merge to the target namespace` |
| 2 | #14 | `fix(ontology): resolve PascalCase IRI collisions instead of fusing tables` |
| 3 | #6 | `fix(infra): deregister the LF admin recorded in PhysicalResourceId…` |
| 4 | — | `test(infra): stop Lambda handler tests fighting over sys.modules["index"]` |
| 5 | #18 | `fix(authz): read every page of a principal's grants, not just the first` |
| 6 | #7 | `fix(sources): make the bulk-approve key-column gate actually reachable` |
| 7 | #13 | `fix(ontology): never rewrite a datatype into an ill-typed literal…` |
| 8 | #16 | `fix(ontology): give every declared property an R2RML mapping…` |
| 9 | #15 | `fix(ontology): parse FK referredColumns by one shared rule` |
| 10 | #8 | `fix(serve): gate the Ontop strategy's class retrieval on mapped classes` |
| 11 | #11 | `fix(serve): don't block generator finalization on the Bedrock stream worker` |
| 12 | #9 | `fix(ontology): paginate list_namespaces so namespaces stop disappearing` |
| 13 | #10 | `fix(infra): hash every input that shapes a Python Lambda bundle` |
| 14 | #12 | `fix(scripts): default SCL_PREFIX to coa, matching the CDK app` |
| 15 | — | `test: fix 13 tests that failed on environment or impossible assertions` |
| 16 | #16 | `fix(ontology): keep every composite-FK relationship when constraints overlap` |
| 17 | #18 | `fix(mcp): fail closed on grant-resolution failure for admins too` |
| 18 | #12 | `fix(scripts): check the runtime is READY instead of faking an invocation` |
| 19 | #11 | `fix(serve): release the Bedrock stream worker when abandoned mid-API-call` |
| 20 | #14 #16 | `fix(ontology): key table IRIs on identity, and let a usable composite FK win` |
| 21 | #12 | `fix(scripts): finish the SCL_PREFIX default migration` |

Commits 16–21 came out of self-review and fix defects the earlier commits
introduced or left. Notably 16: the #16 fix as first written silently dropped a
relationship when two composite FKs share a column — see #16's second section.
Commit 18 likewise replaces 14's smoke-test change, which would have broken every
deploy, so reviewing 14 in isolation is misleading.

Commit 20 closes two holes I found by re-reading my own diff, both cases of an
earlier fix not covering everywhere it claimed. (a) `build_r2rml` tested the
malformed-composite-FK degradation BEFORE the anchor, so a column sitting in a
malformed constraint that also anchored a well-formed one came out as
`rr:datatype` while the ontology declared `rdfs:range` — the exact contradiction
3e9d35a removed — and the usable FK's relationship disappeared from the mapping.
(b) 247d610 keyed the collision helper on `table.name`, but `_catalog_to_tables`
stores the BARE name there, so two `customers` tables from different databases
still collapsed into one TriplesMap with two `rr:tableName` values. Table
identity is now the qualified name, while the bare name still supplies the
display form, so a table with a unique name keeps its byte-identical IRI. Commit
20 also stops the bare PascalCase form being handed out by input order —
`_catalog_to_tables` never sorts, so an enumeration change used to move IRIs
between tables.

## Two places where I did not follow the issue

**#7 (bulk approve gate).** The issue proposes evaluating the gate pre-cascade. I
implemented that and it failed 9 existing tests: `table_enricher` leaves *every*
column `PENDING_REVIEW`, and clearing them is what bulk approve is for, so a
pending check rejects every normal approval. The condition that actually breaks
downstream is a **REJECTED key column on an approved table** — `catalog_reader`
projects only APPROVED columns, so a rejected PK vanishes from the induction
catalog and surfaces later as a PK-column-missing error in Ontop. The gate now
tests that, which is meaningful post-cascade because a bulk APPROVE never turns a
column REJECTED.

**#12 (smoke test).** Making the existing smoke test fatal would have broken every
deploy: the runtime authorizes with JWT, so a SigV4 `invoke-agent-runtime` is
rejected no matter how warm it is. Replaced with a `get-agent-runtime` READY check
— verified against a live deployment (`status` is lowercase and returns `READY`).
An end-to-end query needs an IdP token and belongs in `make test-integ`.

## Verification

All suites pass: ontology-engine 1900, context-manager 1818, sources 888,
control-plane 565, metric-service 358, mcp-server 127, libs/common 499, infra
(jest) 377. `ruff format` / `ruff check` / `prettier` clean. `mypy` reports the
same pre-existing errors as `main` — no new ones.

Commit 15 fixes 13 tests that fail on `main` today — 10 in sources depended on the
developer's `AWS_REGION`, and 3 in metric-service asserted conditions that could
never hold.

## Note

`CONTRIBUTING.md` asks for a `CHANGELOG.md` update under `[Unreleased]`, but the
file does not exist in the repo. Happy to add it if you'd like it created.

