### PR TITLE
test: fix 13 tests that fail on a fresh checkout of main

### DIFF
--- a/packages/metric-service/tests/unit/test_constants.py
+++ b/packages/metric-service/tests/unit/test_constants.py
@@ -35,7 +35,13 @@ class TestInvalidDialectMessage:
     def test_unknown_dialect_has_no_hint(self):
         msg = invalid_dialect_message("ORACLE")
         assert "ORACLE" in msg
-        assert "TRINO" not in msg
+        # Assert on the absence of the HINT, not of the word "TRINO": the base
+        # message always lists every valid dialect (see
+        # test_base_message_lists_valid_dialects), TRINO among them, so
+        # `"TRINO" not in msg` can never hold and contradicted that test.
+        assert dialect_hint("ORACLE") is None
+        assert "use TRINO" not in msg
+        assert "(" not in msg, f"expected no hint suffix, got: {msg}"
 
     def test_base_message_lists_valid_dialects(self):
         msg = invalid_dialect_message("ATHENA")

--- a/packages/metric-service/tests/unit/test_validation_errors.py
+++ b/packages/metric-service/tests/unit/test_validation_errors.py
@@ -6,10 +6,11 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Annotated
 
 import pytest
 from coa_metrics.api.validation_errors import format_validation_error
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
 
 class _SqlDialect(StrEnum):
@@ -23,7 +24,11 @@ class _Dialect(BaseModel):
 
 
 class _Expression(BaseModel):
-    dialects: list[_Dialect]
+    # min_length mirrors the generated MetricExpression
+    # (smithy-generated/.../models/metric_expression.py), so an empty list raises
+    # the too_short error the tests below expect. Without it the stub accepted
+    # `dialects: []` and `_validation_error` failed with "DID NOT RAISE".
+    dialects: Annotated[list[_Dialect], Field(min_length=1)]
 
 
 class _Metric(BaseModel):
@@ -85,4 +90,8 @@ class TestFormatValidationError:
             {"name": "m1", "expression": {"dialects": [{"dialect": "ORACLE", "expression": "SUM(x)"}]}}
         )
         msg = format_validation_error(exc)
-        assert "TRINO" not in msg
+        # Assert the HINT is absent, not the word "TRINO": Pydantic's own enum
+        # error already enumerates the permitted values ("Input should be
+        # 'POSTGRESQL' or 'TRINO'"), so `"TRINO" not in msg` could never hold.
+        assert "use TRINO" not in msg
+        assert "Athena" not in msg

--- a/packages/sources/tests/unit/conftest.py
+++ b/packages/sources/tests/unit/conftest.py
@@ -3,13 +3,33 @@
 
 """Sources unit test configuration.
 
-Required by coa_common.response (lazy check at api_response() call
-time). Set before any handler imports so api_response() can return error
-responses; otherwise every handler test raises RuntimeError("ALLOWED_ORIGIN
-environment variable must be set"). Matches the pattern used by control-plane
-and metric-service unit conftests.
+``ALLOWED_ORIGIN`` is required by coa_common.response (lazy check at
+api_response() call time). Set before any handler imports so api_response() can
+return error responses; otherwise every handler test raises
+RuntimeError("ALLOWED_ORIGIN environment variable must be set"). Matches the
+pattern used by control-plane and metric-service unit conftests.
+
+``AWS_REGION`` is pinned — not ``setdefault``-ed — because the handlers resolve
+their region via ``coa_common.resolve_region()``, which reads ``AWS_REGION``
+FIRST and only then falls back to ``AWS_DEFAULT_REGION``. The moto fixtures
+create their tables in us-east-1 and several test modules set only
+``AWS_DEFAULT_REGION``, so a developer (or CI runner) with ``AWS_REGION`` exported
+to anything else had the handler build its DAO against that region while the
+table lived in us-east-1 — every query failed with ResourceNotFoundException and
+the handler returned 500. That made ~10 tests fail depending on nothing but the
+shell they ran in.
 """
 
 import os
 
 os.environ.setdefault("ALLOWED_ORIGIN", "https://test.example.com")
+
+# Overwrite, don't setdefault: an inherited value is exactly the problem.
+os.environ["AWS_REGION"] = "us-east-1"
+os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+# moto rejects requests with no credentials; keep them obviously fake so a
+# misconfigured test can never reach real AWS.
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
+os.environ.setdefault("AWS_SECURITY_TOKEN", "testing")
+os.environ.setdefault("AWS_SESSION_TOKEN", "testing")


### PR DESCRIPTION
Split from #19 (1/11).

Fixes the 13 unit tests that fail on a fresh checkout of main — they fail on environment assumptions or assert conditions the code can never produce. Test-only change; no production code touched.

Suggest merging this one first so the remaining 10 PRs can be reviewed against a green baseline.

- `packages/metric-service/tests/unit/test_constants.py`
- `packages/metric-service/tests/unit/test_validation_errors.py`
- `packages/sources/tests/unit/conftest.py`