### PR TITLE
fix(infra): deregister the LF admin recorded in PhysicalResourceId

### DIFF
--- a/infra/lib/constructs/lakeformation-admin.ts
+++ b/infra/lib/constructs/lakeformation-admin.ts
@@ -11,6 +11,16 @@ import { Construct } from "constructs";
 export interface LakeFormationAdminProps {
   /** SSM parameter name holding the IAM role ARN to register as an LF data-lake admin. */
   readonly roleArnSsmParameterName: string;
+  /**
+   * The role ARN the SSM parameter resolves to.
+   *
+   * Passed as a custom-resource property purely so a change to the *value*
+   * produces a property diff. With only the parameter *name* as a property, a
+   * deployment that repointed the parameter at a different role left the custom
+   * resource untouched (no diff → no Update → the new role never registered);
+   * the handler still reads the authoritative value from SSM at runtime.
+   */
+  readonly roleArn: string;
 }
 
 /**
@@ -71,7 +81,13 @@ export class LakeFormationAdmin extends Construct {
     });
     new cdk.CustomResource(this, "Resource", {
       serviceToken: provider.serviceToken,
-      properties: { RoleArnSsmParameterName: props.roleArnSsmParameterName },
+      properties: {
+        RoleArnSsmParameterName: props.roleArnSsmParameterName,
+        // Value-carrying property so repointing the parameter triggers an
+        // Update — see LakeFormationAdminProps.roleArn. The handler reads the
+        // authoritative ARN from SSM; this is only a change detector.
+        RoleArn: props.roleArn,
+      },
     });
   }
 }

--- a/infra/lib/lambdas/lakeformation-admin/index.py
+++ b/infra/lib/lambdas/lakeformation-admin/index.py
@@ -3,16 +3,21 @@
 
 """Custom resource — non-destructively registers an IAM role as an LF data-lake admin.
 
-Reads the target role ARN from SSM, then GetDataLakeSettings -> append the role
-to DataLakeAdmins if absent -> PutDataLakeSettings (full settings object), so
-existing admins and other settings are preserved. Removes the role on Delete
-(best-effort, so it never blocks stack teardown). Returns the
-Provider-framework OnEventResponse shape.
+On Create/Update: reads the target role ARN from SSM, then GetDataLakeSettings ->
+append the role to DataLakeAdmins if absent -> PutDataLakeSettings (full settings
+object), so existing admins and other settings are preserved.
+
+On Delete: removes the role recorded in this physical resource's own
+``PhysicalResourceId`` (``lf-admin-{arn}``) — deliberately NOT the current SSM
+value, which under CloudFormation replacement semantics points at the *new* role
+by the time the old resource's cleanup Delete arrives. Best-effort, so an LF
+error never blocks stack teardown, but failures are logged.
+
+Returns the Provider-framework OnEventResponse shape.
 """
 
 from __future__ import annotations
 
-import contextlib
 import re
 
 import boto3
@@ -28,16 +33,14 @@ _sts = boto3.client("sts")
 _ROLE_ARN_RE = re.compile(r"^arn:aws[a-z-]*:iam::(\d{12}):role/.+")
 
 
-def _target(event: dict) -> str:
-    """Resolve and validate the target role ARN from the SSM parameter."""
-    name = event["ResourceProperties"]["RoleArnSsmParameterName"]
-    try:
-        arn = _ssm.get_parameter(Name=name)["Parameter"]["Value"]
-    except ClientError as e:
-        raise ValueError(f"Failed to read SSM parameter {name!r}: {e}") from e
+_PHYSICAL_ID_PREFIX = "lf-admin-"
+
+
+def _validate(arn: str, source: str) -> str:
+    """Validate ``arn`` is a same-account IAM role ARN, or raise."""
     m = _ROLE_ARN_RE.match(arn or "")
     if not m:
-        raise ValueError(f"SSM parameter {name!r} is not an IAM role ARN: {arn!r}")
+        raise ValueError(f"{source} is not an IAM role ARN: {arn!r}")
     try:
         account = _sts.get_caller_identity()["Account"]
     except ClientError as e:
@@ -45,6 +48,46 @@ def _target(event: dict) -> str:
     if m.group(1) != account:
         raise ValueError(f"Refusing to register cross-account principal as LF admin: {arn!r}")
     return arn
+
+
+def _target(event: dict) -> str:
+    """Resolve and validate the target role ARN from the SSM parameter."""
+    name = event["ResourceProperties"]["RoleArnSsmParameterName"]
+    try:
+        arn = _ssm.get_parameter(Name=name)["Parameter"]["Value"]
+    except ClientError as e:
+        raise ValueError(f"Failed to read SSM parameter {name!r}: {e}") from e
+    return _validate(arn, f"SSM parameter {name!r}")
+
+
+def _delete_target(event: dict) -> str | None:
+    """Resolve the ARN this physical resource registered, from its own id.
+
+    Delete MUST deregister the principal *this* physical resource created, which
+    is encoded in ``PhysicalResourceId`` (``lf-admin-{arn}``) — NOT whatever the
+    SSM parameter happens to point at now. When an update changes the role ARN,
+    CloudFormation creates the new physical resource first and then sends a
+    cleanup Delete for the OLD id; resolving from SSM at that point returns the
+    NEW arn, so the handler deregistered the role it had just registered and left
+    the stale one in place. Every LF-privileged operation downstream (federated
+    catalog creation during JDBC scans, LF-governed catalog teardown) then failed
+    with authorization errors unrelated-looking to the deploy — and
+    ``contextlib.suppress`` in the caller hid it while the deployment reported
+    success.
+
+    Returns ``None`` when the id carries no ARN (the ``"lf-admin"`` fallback a
+    failed Create returns, or a resource created before the id carried the ARN),
+    in which case there is nothing safe to deregister and Delete is a no-op.
+    """
+    physical_id = event.get("PhysicalResourceId") or ""
+    if not physical_id.startswith(_PHYSICAL_ID_PREFIX):
+        return None
+    arn = physical_id[len(_PHYSICAL_ID_PREFIX) :]
+    if not arn:
+        return None
+    # Still validate: the id is round-tripped through CloudFormation, and this
+    # keeps the cross-account guard on the deregister path too.
+    return _validate(arn, f"PhysicalResourceId {physical_id!r}")
 
 
 def _apply(request_type: str, target: str) -> None:
@@ -85,10 +128,17 @@ def handler(event: dict, context: object = None) -> dict:
         ``PhysicalResourceId``.
     """
     if event["RequestType"] == "Delete":
-        # Best-effort: never block stack deletion on an LF error.
-        with contextlib.suppress(Exception):
-            _apply("Delete", _target(event))
+        # Deregister the principal recorded in THIS physical resource's id, not
+        # the current SSM value — see _delete_target. Best-effort: never block
+        # stack deletion on an LF error, but log it, since a swallowed failure
+        # here is how a stale admin silently survives a teardown.
+        try:
+            target = _delete_target(event)
+            if target is not None:
+                _apply("Delete", target)
+        except Exception as e:  # noqa: BLE001 - deliberately non-fatal
+            print(f"WARNING: failed to deregister LF admin on Delete: {type(e).__name__}: {e}")
         return {"PhysicalResourceId": event.get("PhysicalResourceId", "lf-admin")}
     target = _target(event)
     _apply(event["RequestType"], target)
-    return {"PhysicalResourceId": f"lf-admin-{target}"}
+    return {"PhysicalResourceId": f"{_PHYSICAL_ID_PREFIX}{target}"}

--- a/infra/lib/stacks/services/sources-stack.ts
+++ b/infra/lib/stacks/services/sources-stack.ts
@@ -723,6 +723,7 @@ export class SourcesStack extends SCLStack {
       "FederationProvisionerLfAdmin",
       {
         roleArnSsmParameterName: `${ssmPrefix}/sources/federation-provisioner-role-arn`,
+        roleArn: fedFnRole.roleArn,
       },
     );
     lfAdmin.node.addDependency(fedRoleArnParam);

--- a/infra/test/lambdas/conftest.py
+++ b/infra/test/lambdas/conftest.py
@@ -1,16 +1,54 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared fixtures for VKG reload Lambda tests.
+"""Shared fixtures for the infra Lambda handler tests.
 
 Patch the boto3 factory to mock the cloudwatch client so it survives the in-test
 `importlib.reload(index)` and never makes real PutMetricData calls.
+
+Adding a test for another Lambda handler here
+-----------------------------------------------
+Every handler in this repo is named ``index.py``. Importing one by its bare
+module name registers it as ``sys.modules["index"]``, so two such test modules
+in this directory fight over that one slot: whichever imports last wins, and
+``@patch("index.<attr>")`` in the other module then resolves against the wrong
+handler and raises ``AttributeError`` — only when the files run together, which
+makes it look like a flaky, order-dependent failure.
+
+``test_vkg_reload_handler.py`` owns the bare ``index`` name (it patches
+``index.ecs`` / ``index.sd`` / ``index.ssm`` in ~19 places). Any NEW handler test
+must load its module under a unique name instead of touching ``sys.path`` — see
+``test_lakeformation_admin_handler.py`` for the ``spec_from_file_location``
+pattern.
 """
 
+import sys
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import boto3
 import pytest
+
+_VKG_RELOAD_DIR = Path(__file__).resolve().parents[2] / "lambda" / "vkg-reload"
+
+
+@pytest.fixture(autouse=True)
+def _guard_index_module_identity():
+    """Fail loudly if ``sys.modules["index"]`` is not the vkg-reload handler.
+
+    Turns the order-dependent ``AttributeError`` described in the module
+    docstring into an explicit, self-explaining failure at the point of
+    contamination, instead of a confusing patch error in an unrelated test.
+    """
+    yield
+    module = sys.modules.get("index")
+    origin = getattr(module, "__file__", None)
+    if origin is not None and Path(origin).parent != _VKG_RELOAD_DIR:
+        pytest.fail(
+            f'sys.modules["index"] is {origin}, not the vkg-reload handler. '
+            "A handler test imported its index.py by bare module name — load it under a "
+            "unique name instead (see this directory's conftest docstring)."
+        )
 
 
 @pytest.fixture(autouse=True)

--- a/infra/test/lambdas/test_lakeformation_admin_handler.py
+++ b/infra/test/lambdas/test_lakeformation_admin_handler.py
@@ -10,14 +10,22 @@ Delete carrying the OLD PhysicalResourceId. Resolving the target from SSM at tha
 point yields the NEW arn, so the handler deregisters the role it just registered.
 """
 
-import importlib
+import importlib.util
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
-_HANDLER_DIR = Path(__file__).resolve().parents[2] / "lib" / "lambdas" / "lakeformation-admin"
+_HANDLER_PATH = Path(__file__).resolve().parents[2] / "lib" / "lambdas" / "lakeformation-admin" / "index.py"
+
+# Every Lambda handler in this repo is named ``index.py``, so importing them by
+# bare module name makes them collide in ``sys.modules["index"]``: whichever test
+# module imports last wins, and ``@patch("index.<attr>")`` in the other one then
+# targets the wrong module (AttributeError). Load this handler under a unique
+# module name via an explicit spec so it never participates in that race — and
+# never mutate ``sys.path``.
+_MODULE_NAME = "lakeformation_admin_index_under_test"
 
 ACCOUNT = "111122223333"
 ROLE_A = f"arn:aws:iam::{ACCOUNT}:role/provisioner-a"
@@ -27,13 +35,13 @@ PARAM = "/coa/sources/federation-provisioner-role-arn"
 
 @pytest.fixture
 def index(monkeypatch):
-    """Import the handler with its module-level boto3 clients stubbed out."""
-    sys.path.insert(0, str(_HANDLER_DIR))
-    try:
-        mod = importlib.import_module("index")
-        mod = importlib.reload(mod)
-    finally:
-        sys.path.remove(str(_HANDLER_DIR))
+    """Import the handler under a unique module name, with boto3 clients stubbed."""
+    spec = importlib.util.spec_from_file_location(_MODULE_NAME, _HANDLER_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[_MODULE_NAME] = mod
+    monkeypatch.delitem(sys.modules, _MODULE_NAME, raising=False)
+    spec.loader.exec_module(mod)
 
     monkeypatch.setattr(mod, "_ssm", MagicMock())
     monkeypatch.setattr(mod, "_lf", MagicMock())

--- a/infra/test/lambdas/test_lakeformation_admin_handler.py
+++ b/infra/test/lambdas/test_lakeformation_admin_handler.py
@@ -1,0 +1,187 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the LakeFormationAdmin custom-resource handler.
+
+The behaviour under test is which principal a Delete deregisters. CloudFormation
+replacement semantics make this subtle: when an Update changes the role ARN, the
+new physical resource is created first and CloudFormation then sends a cleanup
+Delete carrying the OLD PhysicalResourceId. Resolving the target from SSM at that
+point yields the NEW arn, so the handler deregisters the role it just registered.
+"""
+
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_HANDLER_DIR = Path(__file__).resolve().parents[2] / "lib" / "lambdas" / "lakeformation-admin"
+
+ACCOUNT = "111122223333"
+ROLE_A = f"arn:aws:iam::{ACCOUNT}:role/provisioner-a"
+ROLE_B = f"arn:aws:iam::{ACCOUNT}:role/provisioner-b"
+PARAM = "/coa/sources/federation-provisioner-role-arn"
+
+
+@pytest.fixture
+def index(monkeypatch):
+    """Import the handler with its module-level boto3 clients stubbed out."""
+    sys.path.insert(0, str(_HANDLER_DIR))
+    try:
+        mod = importlib.import_module("index")
+        mod = importlib.reload(mod)
+    finally:
+        sys.path.remove(str(_HANDLER_DIR))
+
+    monkeypatch.setattr(mod, "_ssm", MagicMock())
+    monkeypatch.setattr(mod, "_lf", MagicMock())
+    monkeypatch.setattr(mod, "_sts", MagicMock())
+    mod._sts.get_caller_identity.return_value = {"Account": ACCOUNT}
+    return mod
+
+
+def _ssm_returns(index, arn):
+    index._ssm.get_parameter.return_value = {"Parameter": {"Value": arn}}
+
+
+def _lf_admins(index, *arns):
+    index._lf.get_data_lake_settings.return_value = {
+        "DataLakeSettings": {"DataLakeAdmins": [{"DataLakePrincipalIdentifier": a} for a in arns]}
+    }
+
+
+def _written_admins(index):
+    """Return the principals from the last PutDataLakeSettings call."""
+    settings = index._lf.put_data_lake_settings.call_args.kwargs["DataLakeSettings"]
+    return [a["DataLakePrincipalIdentifier"] for a in settings["DataLakeAdmins"]]
+
+
+def _event(request_type, *, physical_id=None):
+    event = {
+        "RequestType": request_type,
+        "ResourceProperties": {"RoleArnSsmParameterName": PARAM, "RoleArn": ROLE_B},
+    }
+    if physical_id is not None:
+        event["PhysicalResourceId"] = physical_id
+    return event
+
+
+class TestCreate:
+    def test_appends_role_and_encodes_it_in_physical_id(self, index):
+        _ssm_returns(index, ROLE_A)
+        _lf_admins(index, "arn:aws:iam::111122223333:role/existing")
+
+        result = index.handler(_event("Create"))
+
+        assert result["PhysicalResourceId"] == f"lf-admin-{ROLE_A}"
+        assert ROLE_A in _written_admins(index)
+
+    def test_preserves_existing_admins(self, index):
+        existing = f"arn:aws:iam::{ACCOUNT}:role/existing"
+        _ssm_returns(index, ROLE_A)
+        _lf_admins(index, existing)
+
+        index.handler(_event("Create"))
+
+        assert existing in _written_admins(index)
+
+    def test_is_idempotent_when_already_admin(self, index):
+        _ssm_returns(index, ROLE_A)
+        _lf_admins(index, ROLE_A)
+
+        index.handler(_event("Create"))
+
+        assert _written_admins(index).count(ROLE_A) == 1
+
+
+class TestDeleteTargetsThePhysicalResource:
+    """Delete must deregister its OWN principal, not the current SSM value."""
+
+    def test_replacement_cleanup_removes_the_old_role_not_the_new_one(self, index):
+        # An Update repointed the parameter from A to B and registered B. CFN now
+        # sends the cleanup Delete for the OLD physical resource, lf-admin-A.
+        _ssm_returns(index, ROLE_B)
+        _lf_admins(index, ROLE_A, ROLE_B)
+
+        index.handler(_event("Delete", physical_id=f"lf-admin-{ROLE_A}"))
+
+        remaining = _written_admins(index)
+        assert ROLE_B in remaining, "deregistered the newly-registered role"
+        assert ROLE_A not in remaining, "left the stale role registered"
+
+    def test_delete_does_not_read_ssm(self, index):
+        _lf_admins(index, ROLE_A)
+
+        index.handler(_event("Delete", physical_id=f"lf-admin-{ROLE_A}"))
+
+        index._ssm.get_parameter.assert_not_called()
+
+    def test_normal_teardown_removes_the_role(self, index):
+        other = f"arn:aws:iam::{ACCOUNT}:role/other-admin"
+        _lf_admins(index, ROLE_A, other)
+
+        index.handler(_event("Delete", physical_id=f"lf-admin-{ROLE_A}"))
+
+        remaining = _written_admins(index)
+        assert ROLE_A not in remaining
+        assert other in remaining, "clobbered an unrelated admin"
+
+
+class TestDeleteEdgeCases:
+    def test_no_op_when_physical_id_carries_no_arn(self, index):
+        """A failed Create returns the bare "lf-admin" sentinel — nothing to remove."""
+        index.handler(_event("Delete", physical_id="lf-admin"))
+
+        index._lf.put_data_lake_settings.assert_not_called()
+
+    def test_no_op_when_physical_id_is_absent(self, index):
+        index.handler(_event("Delete"))
+
+        index._lf.put_data_lake_settings.assert_not_called()
+
+    def test_no_op_for_unrecognized_physical_id(self, index):
+        index.handler(_event("Delete", physical_id="some-other-resource"))
+
+        index._lf.put_data_lake_settings.assert_not_called()
+
+    def test_lf_error_never_blocks_teardown(self, index):
+        _lf_admins(index, ROLE_A)
+        index._lf.put_data_lake_settings.side_effect = RuntimeError("LF unavailable")
+
+        result = index.handler(_event("Delete", physical_id=f"lf-admin-{ROLE_A}"))
+
+        assert result["PhysicalResourceId"] == f"lf-admin-{ROLE_A}"
+
+    def test_cross_account_arn_in_physical_id_is_refused(self, index):
+        """The cross-account guard applies on the deregister path too."""
+        foreign = "arn:aws:iam::999988887777:role/attacker"
+        _lf_admins(index, foreign)
+
+        index.handler(_event("Delete", physical_id=f"lf-admin-{foreign}"))
+
+        index._lf.put_data_lake_settings.assert_not_called()
+
+
+class TestTargetValidation:
+    def test_rejects_non_role_arn_from_ssm(self, index):
+        _ssm_returns(index, f"arn:aws:iam::{ACCOUNT}:user/not-a-role")
+
+        with pytest.raises(ValueError, match="not an IAM role ARN"):
+            index.handler(_event("Create"))
+
+    def test_rejects_cross_account_role(self, index):
+        _ssm_returns(index, "arn:aws:iam::999988887777:role/foreign")
+
+        with pytest.raises(ValueError, match="cross-account"):
+            index.handler(_event("Create"))
+
+    def test_create_failure_propagates(self, index):
+        """A failed registration must fail the deployment, not silently pass."""
+        _ssm_returns(index, ROLE_A)
+        _lf_admins(index, ROLE_A)
+        index._lf.put_data_lake_settings.side_effect = RuntimeError("boom")
+
+        with pytest.raises(RuntimeError):
+            index.handler(_event("Create"))


### PR DESCRIPTION
Split from #19 (2/11). Fixes #6.

On CFN replacement, the LakeFormationAdmin custom resource's Delete read the *current* SSM value and deregistered the NEW role. Delete now uses the role recorded in PhysicalResourceId. Also isolates the Lambda handler tests that were fighting over `sys.modules["index"]`.

File-disjoint from every other PR in the split.
