### PR TITLE
fix(sources): make the bulk-approve key-column gate reachable

### DIFF
--- a/packages/sources/src/coa_sources/database/bulk_review/worker.py
+++ b/packages/sources/src/coa_sources/database/bulk_review/worker.py
@@ -342,6 +342,74 @@ def _verify_in_transient(
     return bool(item and item.get("status") == expected_transient)
 
 
+def _rejected_key_column_reason(assets: list[dict[str, Any]], source_id: str) -> str | None:
+    """Return a denial reason if an approved table would ship without its key columns.
+
+    Runs AFTER the cascade, which is fine — and necessary — because the condition
+    it tests is one the cascade cannot manufacture: a bulk APPROVE never turns a
+    column REJECTED (it flips only ``PENDING_REVIEW`` → ``APPROVED`` and
+    deliberately preserves explicit REJECTED decisions, see
+    ``coa_common.review_logic``). So a REJECTED key column here was rejected by a
+    human, and survives the cascade untouched.
+
+    Why this is the condition that matters: ``catalog_reader`` projects only
+    ``APPROVED`` columns into the induction payload
+    (``_table_to_induction_format``). A REJECTED primary-key column therefore
+    disappears from the catalog while the table itself is APPROVED, and induction
+    mints a subject template with no key to build from — surfacing later as a
+    PK-column-missing error in Ontop, far from the review that caused it. A
+    REJECTED foreign-key column silently drops the relationship instead, so the
+    ontology loses an object property the schema does have.
+
+    This replaces a gate that looked for ``PENDING_REVIEW`` columns *after* the
+    cascade had already flipped every one of them to ``APPROVED`` — structurally
+    unreachable dead code. Checking pending columns pre-cascade is not the fix
+    either: the enricher leaves ALL columns ``PENDING_REVIEW``
+    (``table_enricher.py``), and clearing them is precisely what bulk approve is
+    for, so blocking on pending would reject every normal bulk approval.
+
+    Args:
+        assets: Loaded assets for this page, post-cascade.
+        source_id: Source id, for logging.
+
+    Returns:
+        A human-readable reason when the approval must be blocked, else ``None``.
+    """
+    offenders: list[tuple[str, str, str]] = []  # (table, column, key kind)
+    for asset in assets:
+        table = asset["table"]
+        if table.business_metadata.review_status != ReviewStatus.APPROVED:
+            continue  # not shipping, so its column states are moot
+
+        key_kinds: dict[str, str] = {}
+        for pk_col in table.primary_key.columns or []:
+            key_kinds[pk_col] = "primary key"
+        for fk in table.foreign_keys or []:
+            if fk.column and fk.column not in key_kinds:
+                key_kinds[fk.column] = "foreign key"
+
+        for col in table.columns:
+            kind = key_kinds.get(col.name)
+            if kind and col.business_metadata.review_status == ReviewStatus.REJECTED:
+                offenders.append((table.name, col.name, kind))
+
+    if not offenders:
+        return None
+
+    sample = offenders[:10]
+    logger.warning(
+        "bulk_approve_blocked_rejected_key_columns",
+        extra={"source_id": source_id, "rejected_key_count": len(offenders), "sample": sample},
+    )
+    return (
+        f"Cannot approve: {len(offenders)} key column(s) across "
+        f"{len({t for t, _, _ in offenders})} table(s) are REJECTED, but their tables are approved. "
+        "A rejected key column is dropped from the induction catalog, leaving the table without a "
+        "usable key. Un-reject these columns or reject the whole table. Examples: "
+        + ", ".join(f"{t}.{c} ({kind})" for t, c, kind in sample)
+    )
+
+
 def process_bulk_review(
     *,
     msg: BulkReviewMessage,
@@ -432,36 +500,12 @@ def process_bulk_review(
     # Fold in the count accumulated by earlier pages in the chain.
     tables_approved = msg.tables_approved_so_far + tables_approved_this_page
 
-    # Gate: if approving, verify no column is left in PENDING_REVIEW after the
-    # cascade. Columns that the enricher couldn't auto-approve (structural/identity
-    # columns like PKs/FKs) would break downstream consumers (schema.sql generation
-    # filters to APPROVED-only columns, causing PK-column-missing errors in Ontop).
-    # Fail the approval with a clear message so the user reviews those columns first.
+    # Gate: refuse an approval that would ship a table whose PK/FK column is
+    # REJECTED. See _rejected_key_column_reason for why this is the condition
+    # that actually breaks downstream, and why the previous check could not fire.
     if msg.decision == ReviewDecision.APPROVED and not failed:
-        pending_cols: list[tuple[str, str]] = []
-        for asset in assets:
-            # Only check tables that are APPROVED — rejected/pending tables won't
-            # feed into induction/schema-generation, so their column states are moot.
-            if asset["table"].business_metadata.review_status != ReviewStatus.APPROVED:
-                continue
-            for col in asset["table"].columns:
-                if col.business_metadata.review_status == ReviewStatus.PENDING_REVIEW:
-                    pending_cols.append((asset["table"].name, col.name))
-        if pending_cols:
-            sample = pending_cols[:10]
-            reason = (
-                f"Cannot approve: {len(pending_cols)} column(s) across "
-                f"{len({t for t, _ in pending_cols})} table(s) are still PENDING_REVIEW. "
-                f"Review or approve these columns first. Examples: " + ", ".join(f"{t}.{c}" for t, c in sample)
-            )
-            logger.warning(
-                "bulk_approve_blocked_pending_columns",
-                extra={
-                    "source_id": msg.source_id,
-                    "pending_count": len(pending_cols),
-                    "sample": sample,
-                },
-            )
+        reason = _rejected_key_column_reason(assets, msg.source_id)
+        if reason is not None:
             failed.append(reason)
 
     # More assets remain AND this page had no failures → continue in a fresh

--- a/packages/sources/tests/unit/database/test_bulk_review_worker.py
+++ b/packages/sources/tests/unit/database/test_bulk_review_worker.py
@@ -29,6 +29,8 @@ import coa_sources.database.bulk_review.worker as worker  # noqa: E402
 from coa_common.domain_models import (  # noqa: E402
     BusinessMetadata,
     Column,
+    ForeignKey,
+    PrimaryKey,
     Table,
 )
 from coa_common.review_logic import apply_decision_to_table  # noqa: E402
@@ -745,3 +747,180 @@ class TestBulkReviewPaging:
             )
         assert result.tables_total == 0
         mock_client.search_assets.assert_not_called()
+
+
+# ===================================================================
+# Rejected key-column gate
+# ===================================================================
+
+
+@pytest.mark.unit
+class TestRejectedKeyColumnGate:
+    """An approved table must not ship with a REJECTED primary/foreign key column.
+
+    `catalog_reader._table_to_induction_format` projects only APPROVED columns, so
+    a rejected PK vanishes from the induction catalog while its table stays
+    APPROVED — induction then has no key to build a subject template from and the
+    failure surfaces as a PK-column-missing error in Ontop, far from the review
+    that caused it.
+
+    This gate replaced one that scanned for PENDING_REVIEW columns *after* the
+    bulk cascade had already flipped every one of them to APPROVED (unreachable),
+    and which could not be moved pre-cascade either: the enricher leaves all
+    columns PENDING_REVIEW, so blocking on pending would reject every normal bulk
+    approval.
+    """
+
+    _DAO_PATCH = "coa_sources.database.bulk_review.worker.DynamoDBDAO"
+
+    @staticmethod
+    def _table_with_keys(
+        *,
+        table_name: str = "orders",
+        table_status: str = "APPROVED",
+        columns: list[tuple[str, str]],
+        pk_columns: list[str] | None = None,
+        fk_column: str | None = None,
+    ) -> Table:
+        return Table(
+            name=table_name,
+            database="db",
+            data_source_id=_SOURCE_ID,
+            namespace_id=_NAMESPACE_ID,
+            business_metadata=BusinessMetadata(review_status=table_status),
+            primary_key=PrimaryKey(columns=pk_columns or []),
+            foreign_keys=(
+                [ForeignKey(column=fk_column, target_table="other", target_column="id")] if fk_column else []
+            ),
+            columns=[
+                Column(name=name, data_type="string", business_metadata=BusinessMetadata(review_status=status))
+                for name, status in columns
+            ],
+        )
+
+    def _run(self, tables: list[Table]):
+        mock_dao = MagicMock()
+        mock_dao.get.return_value = {"status": "APPROVING"}
+        mock_client = _mock_smus_with_assets(tables)
+        with patch(self._DAO_PATCH, return_value=mock_dao):
+            return worker.process_bulk_review(
+                msg=worker.BulkReviewMessage(namespace_id=_NAMESPACE_ID, source_id=_SOURCE_ID, decision="APPROVED"),
+                client=mock_client,
+                project_id="proj-123",
+                sources_table="test-sources",
+                region="us-east-1",
+            )
+
+    def test_rejected_primary_key_column_blocks_approval(self):
+        result = self._run(
+            [
+                self._table_with_keys(
+                    columns=[("id", "REJECTED"), ("name", "APPROVED")],
+                    pk_columns=["id"],
+                )
+            ]
+        )
+        assert result.tables_failed, "approval should have been blocked"
+        assert "orders.id (primary key)" in result.tables_failed[0]
+
+    def test_rejected_foreign_key_column_blocks_approval(self):
+        result = self._run(
+            [
+                self._table_with_keys(
+                    columns=[("id", "APPROVED"), ("customer_id", "REJECTED")],
+                    pk_columns=["id"],
+                    fk_column="customer_id",
+                )
+            ]
+        )
+        assert result.tables_failed
+        assert "orders.customer_id (foreign key)" in result.tables_failed[0]
+
+    def test_rejected_non_key_column_does_not_block(self):
+        """Rejecting an ordinary column is a legitimate review decision."""
+        result = self._run(
+            [
+                self._table_with_keys(
+                    columns=[("id", "APPROVED"), ("notes", "REJECTED")],
+                    pk_columns=["id"],
+                )
+            ]
+        )
+        assert result.tables_failed == []
+
+    def test_all_approved_keys_do_not_block(self):
+        result = self._run(
+            [
+                self._table_with_keys(
+                    columns=[("id", "APPROVED"), ("customer_id", "APPROVED")],
+                    pk_columns=["id"],
+                    fk_column="customer_id",
+                )
+            ]
+        )
+        assert result.tables_failed == []
+
+    def test_pending_columns_do_not_block_the_normal_case(self):
+        """The regression the previous gate would have caused if moved pre-cascade.
+
+        The enricher leaves every column PENDING_REVIEW; clearing them is the
+        entire point of bulk approve.
+        """
+        result = self._run(
+            [
+                self._table_with_keys(
+                    table_status="PENDING_REVIEW",
+                    columns=[("id", "PENDING_REVIEW"), ("name", "PENDING_REVIEW")],
+                    pk_columns=["id"],
+                )
+            ]
+        )
+        assert result.tables_failed == []
+        assert result.tables_changed == 1
+
+    def test_rejected_key_on_a_rejected_table_does_not_block(self):
+        """A table that is not shipping cannot break induction."""
+        result = self._run(
+            [
+                self._table_with_keys(
+                    table_status="REJECTED",
+                    columns=[("id", "REJECTED")],
+                    pk_columns=["id"],
+                )
+            ]
+        )
+        assert result.tables_failed == []
+
+    def test_composite_primary_key_partially_rejected_blocks(self):
+        result = self._run(
+            [
+                self._table_with_keys(
+                    columns=[("day", "APPROVED"), ("hour", "REJECTED")],
+                    pk_columns=["day", "hour"],
+                )
+            ]
+        )
+        assert result.tables_failed
+        assert "orders.hour (primary key)" in result.tables_failed[0]
+
+    def test_reject_decision_never_runs_the_gate(self):
+        """The gate guards approvals only; a bulk REJECT is always allowed."""
+        mock_dao = MagicMock()
+        mock_dao.get.return_value = {"status": "REJECTING"}
+        tables = [
+            self._table_with_keys(
+                table_status="APPROVED",
+                columns=[("id", "REJECTED")],
+                pk_columns=["id"],
+            )
+        ]
+        mock_client = _mock_smus_with_assets(tables)
+        with patch(self._DAO_PATCH, return_value=mock_dao):
+            result = worker.process_bulk_review(
+                msg=worker.BulkReviewMessage(namespace_id=_NAMESPACE_ID, source_id=_SOURCE_ID, decision="REJECTED"),
+                client=mock_client,
+                project_id="proj-123",
+                sources_table="test-sources",
+                region="us-east-1",
+            )
+        assert result.tables_failed == []


### PR DESCRIPTION
Split from #19 (3/11). Fixes #7.

The safety gate for PENDING_REVIEW key columns ran *after* the cascade that clears them, so it could never fire. The gate now runs before the cascade.

File-disjoint from every other PR in the split.
