### PR TITLE
fix(serve): gate Ontop class retrieval on mapped classes

### DIFF
--- a/packages/context-manager/src/coa_serve/tier2/ontop/strategy.py
+++ b/packages/context-manager/src/coa_serve/tier2/ontop/strategy.py
@@ -29,6 +29,9 @@ logger = structlog.get_logger(__name__)
 
 _TIER2_TOOL_USED = TOOL_FOR_STEP
 
+# k-NN depth for the TBox-context retrieval feeding NL→SPARQL.
+_VECTOR_TOP_K = 10
+
 _RETRYABLE_VKG_PATTERNS = (
     "cannot translate",
     "unsupported sparql",
@@ -305,10 +308,54 @@ class OntopStrategy:
             return None
         try:
             index_name = ontology_vector_index_name(self._oss_ontology_index, namespace)
-            raw_hits = await self._vector_client.search(embedding, namespace=namespace, top_k=10, index=index_name)
-            logger.debug(
+
+            # Restrict the CLASS retrieval to R2RML-mapped classes, matching the
+            # gate NL→SQL applies (nl_to_sql/sql_generator.py). Unmapped classes —
+            # document-induced or from a loaded foundational ontology — have no
+            # table behind them, so authoring SPARQL against them produces a query
+            # VKG cannot compile: nothing comes back, in exactly the mixed
+            # DATABASE + DOCUMENTS namespace the ``is_mapped`` design exists to
+            # protect (see external-docs "Mapped classes and Tier-2
+            # answerability"). Without the gate a document-heavy query filled the
+            # top-k with unmapped classes; the provenance skip evaluator only
+            # bails when ALL top-k hits are unmapped, so the partial mix fell
+            # through untouched.
+            #
+            # Legacy bridge, same as NL→SQL: namespaces ingested before
+            # ``data_source_id`` was written carry zero mapped records, and gating
+            # them would hide every class. One cheap count decides whether the
+            # gate applies at all.
+            mapped_count = await self._vector_client.count_documents(
+                index=index_name, entity_type="class", require_mapped=True
+            )
+            use_mapped_gate = mapped_count > 0
+
+            class_hits = await self._vector_client.search(
+                embedding,
+                namespace=namespace,
+                top_k=_VECTOR_TOP_K,
+                index=index_name,
+                entity_type="class",
+                require_mapped=use_mapped_gate,
+            )
+            # Properties and metrics are fetched unfiltered: only classes carry the
+            # data_source_id stamp the mapped gate reads, and metrics are resolved
+            # through Tier-1 rather than the VKG mapping. Classes are dropped from
+            # this pass — they are already covered by the gated search above, and
+            # keeping them would both duplicate hits and reintroduce the unmapped
+            # classes the gate just excluded.
+            other_hits = await self._vector_client.search(
+                embedding, namespace=namespace, top_k=_VECTOR_TOP_K, index=index_name
+            )
+            raw_hits = [*class_hits, *(h for h in other_hits if h.metadata.get("entity_type") != "class")]
+
+            logger.info(
                 "tier2_aoss_raw_hits",
+                namespace=namespace,
                 count=len(raw_hits),
+                mapped_gate=use_mapped_gate,
+                mapped_count=mapped_count,
+                class_hits=len(class_hits),
                 sample_types=[h.metadata.get("entity_type", "MISSING") for h in raw_hits[:5]],
             )
             hits = []

--- a/packages/context-manager/tests/unit/test_ontop_strategy.py
+++ b/packages/context-manager/tests/unit/test_ontop_strategy.py
@@ -347,14 +347,24 @@ class TestOntopStrategyVectorHits:
             oss_ontology_index="test-index",
         )
 
-        # Vector search returns mixed entity types
-        vector_client.search.return_value = [
-            BaseVectorHit(id="1", text="ClassA", score=0.9, metadata={"entity_type": "class", "entity_uri": "uri:A"}),
-            BaseVectorHit(
-                id="2", text="PropB", score=0.85, metadata={"entity_type": "property", "entity_uri": "uri:B"}
-            ),
-            BaseVectorHit(id="3", text="MetricC", score=0.8, metadata={"entity_type": "metric", "entity_uri": "uri:C"}),
-            BaseVectorHit(id="4", text="Unknown", score=0.7, metadata={"entity_type": "unknown"}),
+        # Classes are retrieved in their own mapped-gated search; properties and
+        # metrics come from the unfiltered one (see _fetch_vector_hits).
+        class_hit = BaseVectorHit(
+            id="1", text="ClassA", score=0.9, metadata={"entity_type": "class", "entity_uri": "uri:A"}
+        )
+        vector_client.count_documents.return_value = 5  # namespace has mapped classes
+        vector_client.search.side_effect = [
+            [class_hit],
+            [
+                class_hit,  # re-returned by the unfiltered pass; must not be counted twice
+                BaseVectorHit(
+                    id="2", text="PropB", score=0.85, metadata={"entity_type": "property", "entity_uri": "uri:B"}
+                ),
+                BaseVectorHit(
+                    id="3", text="MetricC", score=0.8, metadata={"entity_type": "metric", "entity_uri": "uri:C"}
+                ),
+                BaseVectorHit(id="4", text="Unknown", score=0.7, metadata={"entity_type": "unknown"}),
+            ],
         ]
         nl_to_sparql.translate.return_value = _make_sparql_result(valid=False)
 
@@ -370,6 +380,107 @@ class TestOntopStrategyVectorHits:
         assert hits[0].type == "ontology_class"
         assert hits[1].type == "ontology_property"
         assert hits[2].type == "metric"
+
+    # ── mapped-class gate (parity with nl_to_sql/sql_generator.py) ───────────
+    # Unmapped classes (document-induced, or from a loaded foundational ontology)
+    # have no table behind them, so SPARQL authored against them cannot compile in
+    # VKG and the query silently returns nothing. NL→SQL gated its class retrieval
+    # on `require_mapped`; the Ontop path did not, so a document-heavy query in a
+    # mixed namespace filled its top-k with unmapped classes. The provenance skip
+    # evaluator only bails when ALL top-k hits are unmapped, so the partial mix
+    # fell straight through.
+
+    def _strategy(self, nl_to_sparql, vkg_translator, vector_client):
+        return OntopStrategy(
+            nl_to_sparql=nl_to_sparql,
+            vkg_translator=vkg_translator,
+            vector_client=vector_client,
+            oss_ontology_index="test-index",
+        )
+
+    @pytest.mark.asyncio
+    async def test_class_search_is_gated_on_mapped_when_mapped_classes_exist(
+        self, nl_to_sparql, vkg_translator, vector_client
+    ):
+        vector_client.count_documents.return_value = 3
+        vector_client.search.return_value = []
+        nl_to_sparql.translate.return_value = _make_sparql_result(valid=False)
+
+        await self._strategy(nl_to_sparql, vkg_translator, vector_client).resolve(
+            "query", "ns1", _make_context(embedding=[0.1] * 10)
+        )
+
+        class_call = next(c for c in vector_client.search.call_args_list if c.kwargs.get("entity_type") == "class")
+        assert class_call.kwargs["require_mapped"] is True
+
+    @pytest.mark.asyncio
+    async def test_gate_is_dropped_for_a_namespace_with_no_mapped_classes(
+        self, nl_to_sparql, vkg_translator, vector_client
+    ):
+        """Legacy bridge: gating a namespace ingested before data_source_id existed
+        would hide every class and take Tier-2 dark."""
+        vector_client.count_documents.return_value = 0
+        vector_client.search.return_value = []
+        nl_to_sparql.translate.return_value = _make_sparql_result(valid=False)
+
+        await self._strategy(nl_to_sparql, vkg_translator, vector_client).resolve(
+            "query", "ns1", _make_context(embedding=[0.1] * 10)
+        )
+
+        class_call = next(c for c in vector_client.search.call_args_list if c.kwargs.get("entity_type") == "class")
+        assert class_call.kwargs["require_mapped"] is False
+
+    @pytest.mark.asyncio
+    async def test_unmapped_classes_from_the_unfiltered_pass_are_excluded(
+        self, nl_to_sparql, vkg_translator, vector_client
+    ):
+        """The second (unfiltered) search exists for properties/metrics only — its
+        classes must not slip past the gate."""
+        vector_client.count_documents.return_value = 2
+        vector_client.search.side_effect = [
+            [
+                BaseVectorHit(
+                    id="1", text="MappedClass", score=0.9, metadata={"entity_type": "class", "entity_uri": "uri:mapped"}
+                )
+            ],
+            [
+                BaseVectorHit(
+                    id="9",
+                    text="UnmappedDocClass",
+                    score=0.95,
+                    metadata={"entity_type": "class", "entity_uri": "uri:unmapped"},
+                ),
+                BaseVectorHit(
+                    id="2", text="PropB", score=0.8, metadata={"entity_type": "property", "entity_uri": "uri:B"}
+                ),
+            ],
+        ]
+        nl_to_sparql.translate.return_value = _make_sparql_result(valid=False)
+
+        await self._strategy(nl_to_sparql, vkg_translator, vector_client).resolve(
+            "query", "ns1", _make_context(embedding=[0.1] * 10)
+        )
+
+        hits = nl_to_sparql.translate.call_args[1]["vector_hits"]
+        uris = {h.uri for h in hits}
+        assert "uri:mapped" in uris
+        assert "uri:unmapped" not in uris, "an unmapped class reached the NL→SPARQL context"
+
+    @pytest.mark.asyncio
+    async def test_properties_and_metrics_are_not_mapped_gated(self, nl_to_sparql, vkg_translator, vector_client):
+        """Only classes carry the data_source_id stamp the gate reads."""
+        vector_client.count_documents.return_value = 4
+        vector_client.search.return_value = []
+        nl_to_sparql.translate.return_value = _make_sparql_result(valid=False)
+
+        await self._strategy(nl_to_sparql, vkg_translator, vector_client).resolve(
+            "query", "ns1", _make_context(embedding=[0.1] * 10)
+        )
+
+        unfiltered = [c for c in vector_client.search.call_args_list if "entity_type" not in c.kwargs]
+        assert unfiltered, "expected an unfiltered search for properties/metrics"
+        for call in unfiltered:
+            assert not call.kwargs.get("require_mapped")
 
     @pytest.mark.asyncio
     async def test_vector_search_exception_returns_none_gracefully(self, nl_to_sparql, vkg_translator, vector_client):


### PR DESCRIPTION
Split from #19 (4/11). Fixes #8.

The Tier-2 Ontop strategy was missing the `require_mapped` class-search gate that NL-to-SQL applies, so it could retrieve classes with no VKG mapping. It now applies the same gate.

File-disjoint from every other PR in the split.
