### PR TITLE
fix(ontology): paginate list_namespaces

### DIFF
--- a/packages/ontology-engine/src/coa_ontology/dynamo_store.py
+++ b/packages/ontology-engine/src/coa_ontology/dynamo_store.py
@@ -1329,16 +1329,32 @@ def get_namespace_meta(namespace: str) -> dict | None:
 def list_namespaces(limit: int = 100) -> list[dict]:
     """Return every namespace META row.
 
-    Uses a Scan with filter on ``SK = "META"`` and ``begins_with(PK, "NAMESPACE#")``.
-    For small deployments (dozens of namespaces) this is fine; add a GSI
-    later if the namespace count grows past a few hundred.
+    Scans with a filter on ``SK = "META"`` and ``begins_with(PK, "NAMESPACE#")``,
+    following ``LastEvaluatedKey`` until ``limit`` matches are collected or the
+    table is exhausted.
+
+    The pagination is NOT about the namespace count. DynamoDB applies ``Limit`` to
+    the number of items **evaluated before filtering**, not to matches returned,
+    and this single-table design stores job, proposal, and ingest-job rows
+    alongside the ``NAMESPACE#`` ones. With more than ``limit`` such rows — normal
+    after modest usage — the first scanned page can contain few or zero namespace
+    rows, and a single-page read simply omitted the rest with no error. ``list_jobs``
+    / ``list_proposals`` / ``list_ingest_jobs`` in this module already paginate for
+    exactly this reason; this path was the one left behind.
     """
-    resp = _get_table().scan(
-        FilterExpression="begins_with(PK, :p) AND SK = :sk",
-        ExpressionAttributeValues={":p": "NAMESPACE#", ":sk": "META"},
-        Limit=limit,
-    )
-    return resp.get("Items", [])
+    kwargs: dict = {
+        "FilterExpression": "begins_with(PK, :p) AND SK = :sk",
+        "ExpressionAttributeValues": {":p": "NAMESPACE#", ":sk": "META"},
+    }
+    items: list[dict] = []
+    while len(items) < limit:
+        resp = _get_table().scan(**kwargs)
+        items.extend(resp.get("Items", []))
+        last_key = resp.get("LastEvaluatedKey")
+        if not last_key:
+            break
+        kwargs["ExclusiveStartKey"] = last_key
+    return items[:limit]
 
 
 def put_ontology_registry(namespace: str, ontology_id: str, data: dict) -> dict:

--- a/packages/ontology-engine/tests/unit/test_dynamo_store.py
+++ b/packages/ontology-engine/tests/unit/test_dynamo_store.py
@@ -733,6 +733,90 @@ class TestListProposalsScanPaginationDrain:
         assert {r["proposal_id"] for r in rows} == {"p1", "p2", "p3"}
 
 
+class TestListNamespacesScanPagination:
+    """``list_namespaces`` must follow ``LastEvaluatedKey``.
+
+    DynamoDB applies ``Limit`` to items EVALUATED before filtering, not to matches
+    returned. This single-table design stores job / proposal / ingest-job rows
+    alongside the ``NAMESPACE#`` ones, so once the table holds more non-namespace
+    rows than the limit, a single-page scan returns few or zero namespaces and
+    silently omits the rest — driven by TOTAL item count, not namespace count.
+    """
+
+    @staticmethod
+    def _seed_namespace(table, name: str) -> None:
+        table.put_item(Item={"PK": f"NAMESPACE#{name}", "SK": "META", "namespace": name})
+
+    @staticmethod
+    def _seed_noise(table, n: int) -> None:
+        """Non-namespace rows of the kind that accumulate in normal use."""
+        for i in range(n):
+            table.put_item(Item={"PK": f"NS#x#JOB#{i}", "SK": "STATUS", "job_id": str(i)})
+
+    def test_namespace_on_a_later_page_is_returned(self, monkeypatch):
+        from coa_ontology import dynamo_store as ds
+
+        table = _FakeDynamoTable(page_size=2)
+        self._seed_namespace(table, "ns-a")
+        self._seed_namespace(table, "ns-b")
+        self._seed_namespace(table, "ns-c")  # lands on page 2
+        monkeypatch.setattr(ds, "_get_table", lambda: table)
+
+        rows = ds.list_namespaces()
+
+        assert {r["namespace"] for r in rows} == {"ns-a", "ns-b", "ns-c"}
+
+    def test_namespaces_hidden_behind_unrelated_rows_are_still_found(self, monkeypatch):
+        """The actual production failure mode.
+
+        The old code passed ``Limit=limit`` (100), and DynamoDB applies Limit to
+        items EVALUATED, so with >100 job/proposal rows ahead of the namespace rows
+        the single page it read contained no namespaces at all. Seeds past the
+        default limit so the first evaluated page is entirely noise.
+        """
+        from coa_ontology import dynamo_store as ds
+
+        table = _FakeDynamoTable(page_size=40)
+        self._seed_noise(table, 150)  # more than the default limit of 100
+        self._seed_namespace(table, "ns-late")
+        monkeypatch.setattr(ds, "_get_table", lambda: table)
+
+        rows = ds.list_namespaces()
+
+        assert {r["namespace"] for r in rows} == {"ns-late"}
+
+    def test_limit_still_caps_the_result(self, monkeypatch):
+        from coa_ontology import dynamo_store as ds
+
+        table = _FakeDynamoTable(page_size=2)
+        for i in range(5):
+            self._seed_namespace(table, f"ns-{i}")
+        monkeypatch.setattr(ds, "_get_table", lambda: table)
+
+        assert len(ds.list_namespaces(limit=3)) == 3
+
+    def test_only_namespace_meta_rows_are_returned(self, monkeypatch):
+        from coa_ontology import dynamo_store as ds
+
+        table = _FakeDynamoTable(page_size=3)
+        self._seed_namespace(table, "ns-a")
+        self._seed_noise(table, 4)
+        # A NAMESPACE# partition row that is not the META row must not match.
+        table.put_item(Item={"PK": "NAMESPACE#ns-a", "SK": "OTHER", "namespace": "ns-a"})
+        monkeypatch.setattr(ds, "_get_table", lambda: table)
+
+        rows = ds.list_namespaces()
+
+        assert [r["SK"] for r in rows] == ["META"]
+
+    def test_empty_table_returns_empty(self, monkeypatch):
+        from coa_ontology import dynamo_store as ds
+
+        monkeypatch.setattr(ds, "_get_table", lambda: _FakeDynamoTable(page_size=2))
+
+        assert ds.list_namespaces() == []
+
+
 class TestListProposalsCrossNamespaceContainsFilter:
     """``list_proposals(namespace=None)`` filters on ``contains(PK, "#PROPOSAL#")``.
 


### PR DESCRIPTION
Split from #19 (5/11). Fixes #9.

list_namespaces used a single Scan with a pre-filter Limit and no pagination, so namespaces silently disappeared once the table grew. It now paginates through the full result set.

File-disjoint from every other PR in the split.
