### PR TITLE
fix(infra): hash every input that shapes a Python Lambda bundle

### DIFF
--- a/infra/lib/utils/python-bundling.ts
+++ b/infra/lib/utils/python-bundling.ts
@@ -75,8 +75,10 @@ function resolvePipCommand(): string {
  * ```
  */
 export function bundlePython(opts: PythonBundlingOptions): lambda.Code {
-  // Compute a stable hash from only the files that matter for this Lambda.
-  const assetHash = _computeSourceHash(opts.srcDirs, opts.requirementsFile);
+  // Compute a stable hash over EVERY input that affects the produced bundle.
+  // Omitting one means CDK reuses a stale cached asset and the Lambda keeps
+  // running old code or old dependencies, with no error at deploy time.
+  const assetHash = _computeSourceHash(opts);
 
   // Normalize all source paths to forward slashes for Docker compatibility
   const srcDirs = opts.srcDirs.map((d) => d.replace(/\\/g, "/"));
@@ -94,10 +96,15 @@ export function bundlePython(opts: PythonBundlingOptions): lambda.Code {
     "s3transfer",
     "jmespath",
   ];
+  // Anchor the dist-info glob on the version separator (`-`) so it cannot match a
+  // DIFFERENT package that merely starts with the same name: `boto3*dist-info`
+  // also matched `boto3_stubs-1.2.3.dist-info`, deleting that package's metadata
+  // while leaving its code in place — a half-removed install. A real dist-info is
+  // always `{name}-{version}.dist-info`.
   const cleanup = runtimePkgs
     .map(
       (p) =>
-        `rm -rf /asset-output/${p} /asset-output/${p.replace("-", "_")}*dist-info`,
+        `rm -rf /asset-output/${p} /asset-output/${p.replace("-", "_")}-*.dist-info`,
     )
     .join(" && ");
 
@@ -157,58 +164,87 @@ function escapeRegExp(s: string): string {
 }
 
 /**
- * Compute a stable SHA-256 hash from only the source files and requirements
- * that actually affect this Lambda bundle. Used as a custom CDK asset hash
- * so that unrelated repo changes (test outputs, coverage files, etc.) don't
- * trigger unnecessary re-bundles.
+ * Compute a stable SHA-256 hash over every input that affects this Lambda
+ * bundle. Used as a custom CDK asset hash so unrelated repo changes (test
+ * outputs, coverage files, …) don't trigger needless re-bundles.
  *
- * On Linux/macOS: uses `find | sort | xargs sha256sum` (preserves existing hashes).
- * On Windows: uses Node.js fs (quiet, no shell noise).
+ * Hashes ALL files under `srcDirs` — not just `*.py`. The bundle command copies
+ * everything (`cp -r ${d}/*`), so JSON/schema/template files shipped alongside
+ * the code are part of the output and must invalidate the asset when edited.
+ *
+ * Also folds in `pipDeps` and `architecture`, which change the produced bundle
+ * without touching any file:
+ *   - `pipDeps` is the alternative to `requirementsFile`; callers using it could
+ *     add, remove, or re-pin a dependency with no hash change, so the deployed
+ *     bundle kept the old dependency set (symptom: `ImportModuleError` for a
+ *     freshly added dep).
+ *   - `architecture` selects the pip `--platform` tag and therefore which binary
+ *     wheels land in the bundle, so flipping x86_64 ↔ arm64 reused an asset built
+ *     for the wrong architecture.
+ *
+ * Reads files via Node on every platform. The previous `find … || true` shell
+ * pipeline was unquoted and failure-suppressed, so a repo path containing a space
+ * degraded every hash to the empty-input hash — permanently disabling
+ * invalidation — and any `find` failure passed silently.
  */
-function _computeSourceHash(
-  srcDirs: string[],
-  requirementsFile?: string,
-): string {
+export function _computeSourceHash(opts: PythonBundlingOptions): string {
   const hash = crypto.createHash("sha256");
-  for (const dir of srcDirs) {
-    try {
-      if (process.platform === "win32") {
-        const normalizedDir = dir.replace(/\\/g, "/");
-        const files = _collectPyFiles(normalizedDir).sort();
-        for (const file of files) {
-          const fileHash = crypto
-            .createHash("sha256")
-            .update(fs.readFileSync(file))
-            .digest("hex");
-          hash.update(`${fileHash}  ${file}\n`);
-        }
-      } else {
-        const out = execSync(
-          `find ${dir} -type f -name "*.py" | sort | xargs sha256sum 2>/dev/null || true`,
-          { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
-        );
-        hash.update(out);
-      }
-    } catch {
-      // Directory may not exist yet — ignore
+
+  // Bundle-shaping inputs first, so they are covered even if a srcDir is absent.
+  hash.update(`architecture:${opts.architecture ?? "x86_64"}\n`);
+  if (opts.pipDeps?.length) {
+    // Sorted: dependency ORDER does not change the installed set, so it must not
+    // change the hash (an unsorted list would cause spurious re-bundles).
+    hash.update(`pipDeps:${[...opts.pipDeps].sort().join(",")}\n`);
+  }
+
+  for (const dir of opts.srcDirs) {
+    const normalizedDir = dir.replace(/\\/g, "/");
+    if (!fs.existsSync(normalizedDir)) {
+      // A source dir that does not exist yet still has to affect the hash, or
+      // creating it later would not invalidate the asset.
+      hash.update(`missing:${normalizedDir}\n`);
+      continue;
+    }
+    for (const file of _collectFiles(normalizedDir).sort()) {
+      const fileHash = crypto
+        .createHash("sha256")
+        .update(fs.readFileSync(file))
+        .digest("hex");
+      // Path is included so a rename alone invalidates the asset.
+      hash.update(`${fileHash}  ${file}\n`);
     }
   }
-  if (requirementsFile && fs.existsSync(requirementsFile)) {
-    hash.update(fs.readFileSync(requirementsFile));
+
+  if (opts.requirementsFile) {
+    if (fs.existsSync(opts.requirementsFile)) {
+      hash.update(fs.readFileSync(opts.requirementsFile));
+    } else {
+      hash.update(`missing:${opts.requirementsFile}\n`);
+    }
   }
   return hash.digest("hex");
 }
 
-/** Recursively collect all .py file paths in a directory. */
-function _collectPyFiles(dir: string): string[] {
+/**
+ * Recursively collect every file path in a directory.
+ *
+ * Deliberately NOT limited to `*.py`: the bundle copies the whole tree, so any
+ * non-Python file it ships (JSON, schemas, templates, Cedar policies) must
+ * invalidate the asset when edited.
+ *
+ * `__pycache__` is skipped — it is build output, not input, and hashing it would
+ * make the asset depend on whether tests happened to run first.
+ */
+function _collectFiles(dir: string): string[] {
   if (!fs.existsSync(dir)) return [];
   const results: string[] = [];
-  const entries = fs.readdirSync(dir, { withFileTypes: true });
-  for (const entry of entries) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const fullPath = `${dir}/${entry.name}`;
     if (entry.isDirectory()) {
-      results.push(..._collectPyFiles(fullPath));
-    } else if (entry.isFile() && entry.name.endsWith(".py")) {
+      if (entry.name === "__pycache__") continue;
+      results.push(..._collectFiles(fullPath));
+    } else if (entry.isFile() && !entry.name.endsWith(".pyc")) {
       results.push(fullPath);
     }
   }

--- a/infra/test/utils/python-bundling.test.ts
+++ b/infra/test/utils/python-bundling.test.ts
@@ -1,0 +1,223 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { _computeSourceHash } from "../../lib/utils/python-bundling";
+
+/**
+ * The asset hash is what CDK uses to decide whether to re-bundle. Any input that
+ * changes the produced bundle but NOT the hash means a stale cached asset is
+ * silently reused — the Lambda keeps running old code or old dependencies with no
+ * error at deploy time.
+ */
+describe("bundlePython asset hash", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "coa-bundle-hash-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  /** Create a src dir with the given relative files, return its absolute path. */
+  function srcDir(name: string, files: Record<string, string>): string {
+    const dir = path.join(root, name);
+    for (const [rel, content] of Object.entries(files)) {
+      const full = path.join(dir, rel);
+      fs.mkdirSync(path.dirname(full), { recursive: true });
+      fs.writeFileSync(full, content);
+    }
+    fs.mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  describe("source files", () => {
+    it("changes when a .py file changes", () => {
+      const dir = srcDir("a", { "mod.py": "x = 1" });
+      const before = _computeSourceHash({ srcDirs: [dir] });
+
+      fs.writeFileSync(path.join(dir, "mod.py"), "x = 2");
+
+      expect(_computeSourceHash({ srcDirs: [dir] })).not.toEqual(before);
+    });
+
+    it("changes when a NON-.py file changes", () => {
+      // The bundle copies everything (`cp -r ${d}/*`), so a schema/JSON file
+      // shipped alongside the code is part of the output.
+      const dir = srcDir("a", { "mod.py": "x = 1", "schema.json": '{"v":1}' });
+      const before = _computeSourceHash({ srcDirs: [dir] });
+
+      fs.writeFileSync(path.join(dir, "schema.json"), '{"v":2}');
+
+      expect(_computeSourceHash({ srcDirs: [dir] })).not.toEqual(before);
+    });
+
+    it("changes when a nested file changes", () => {
+      const dir = srcDir("a", { "pkg/sub/mod.py": "x = 1" });
+      const before = _computeSourceHash({ srcDirs: [dir] });
+
+      fs.writeFileSync(path.join(dir, "pkg/sub/mod.py"), "x = 2");
+
+      expect(_computeSourceHash({ srcDirs: [dir] })).not.toEqual(before);
+    });
+
+    it("changes when a file is renamed but content is identical", () => {
+      const dir = srcDir("a", { "old.py": "x = 1" });
+      const before = _computeSourceHash({ srcDirs: [dir] });
+
+      fs.renameSync(path.join(dir, "old.py"), path.join(dir, "new.py"));
+
+      expect(_computeSourceHash({ srcDirs: [dir] })).not.toEqual(before);
+    });
+
+    it("is stable across calls with no changes", () => {
+      const dir = srcDir("a", { "mod.py": "x = 1", "data.json": "{}" });
+
+      expect(_computeSourceHash({ srcDirs: [dir] })).toEqual(
+        _computeSourceHash({ srcDirs: [dir] }),
+      );
+    });
+
+    it("ignores __pycache__ so a prior test run cannot change the hash", () => {
+      const dir = srcDir("a", { "mod.py": "x = 1" });
+      const before = _computeSourceHash({ srcDirs: [dir] });
+
+      fs.mkdirSync(path.join(dir, "__pycache__"), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, "__pycache__/mod.cpython-312.pyc"),
+        "\x00",
+      );
+
+      expect(_computeSourceHash({ srcDirs: [dir] })).toEqual(before);
+    });
+
+    it("handles a path containing spaces", () => {
+      // The old shell pipeline was unquoted and failure-suppressed (`|| true`),
+      // so a path with a space degraded every hash to the empty-input hash —
+      // permanently disabling invalidation.
+      const dir = srcDir("dir with space", { "mod.py": "x = 1" });
+      const before = _computeSourceHash({ srcDirs: [dir] });
+
+      fs.writeFileSync(path.join(dir, "mod.py"), "x = 2");
+      const after = _computeSourceHash({ srcDirs: [dir] });
+
+      expect(after).not.toEqual(before);
+      expect(before).not.toEqual(_computeSourceHash({ srcDirs: [] }));
+    });
+
+    it("distinguishes a missing src dir from an empty one", () => {
+      const missing = path.join(root, "not-created");
+      const empty = srcDir("empty", {});
+
+      expect(_computeSourceHash({ srcDirs: [missing] })).not.toEqual(
+        _computeSourceHash({ srcDirs: [empty] }),
+      );
+    });
+  });
+
+  describe("pipDeps", () => {
+    it("changes when a dependency is added", () => {
+      const dir = srcDir("a", { "mod.py": "x = 1" });
+      const before = _computeSourceHash({
+        srcDirs: [dir],
+        pipDeps: ["pydantic"],
+      });
+
+      const after = _computeSourceHash({
+        srcDirs: [dir],
+        pipDeps: ["pydantic", "structlog"],
+      });
+
+      expect(after).not.toEqual(before);
+    });
+
+    it("changes when a dependency is removed", () => {
+      const dir = srcDir("a", { "mod.py": "x = 1" });
+      const before = _computeSourceHash({
+        srcDirs: [dir],
+        pipDeps: ["pydantic", "structlog"],
+      });
+
+      expect(
+        _computeSourceHash({ srcDirs: [dir], pipDeps: ["pydantic"] }),
+      ).not.toEqual(before);
+    });
+
+    it("changes when a dependency is re-pinned", () => {
+      const dir = srcDir("a", { "mod.py": "x = 1" });
+      const before = _computeSourceHash({
+        srcDirs: [dir],
+        pipDeps: ["pydantic==2.1.0"],
+      });
+
+      expect(
+        _computeSourceHash({ srcDirs: [dir], pipDeps: ["pydantic==2.2.0"] }),
+      ).not.toEqual(before);
+    });
+
+    it("does NOT change when only the order differs", () => {
+      // Order does not change the installed set, so it must not cause a re-bundle.
+      const dir = srcDir("a", { "mod.py": "x = 1" });
+
+      expect(
+        _computeSourceHash({ srcDirs: [dir], pipDeps: ["a", "b"] }),
+      ).toEqual(_computeSourceHash({ srcDirs: [dir], pipDeps: ["b", "a"] }));
+    });
+  });
+
+  describe("architecture", () => {
+    it("changes between x86_64 and arm64", () => {
+      // Selects the pip --platform tag, and therefore which binary wheels are in
+      // the bundle. Reusing an asset across architectures ships wrong wheels.
+      const dir = srcDir("a", { "mod.py": "x = 1" });
+
+      expect(
+        _computeSourceHash({ srcDirs: [dir], architecture: "arm64" }),
+      ).not.toEqual(
+        _computeSourceHash({ srcDirs: [dir], architecture: "x86_64" }),
+      );
+    });
+
+    it("treats an omitted architecture as the x86_64 default", () => {
+      const dir = srcDir("a", { "mod.py": "x = 1" });
+
+      expect(_computeSourceHash({ srcDirs: [dir] })).toEqual(
+        _computeSourceHash({ srcDirs: [dir], architecture: "x86_64" }),
+      );
+    });
+  });
+
+  describe("requirementsFile", () => {
+    it("changes when the requirements content changes", () => {
+      const dir = srcDir("a", { "mod.py": "x = 1" });
+      const req = path.join(root, "requirements.txt");
+      fs.writeFileSync(req, "pydantic==2.1.0\n");
+      const before = _computeSourceHash({
+        srcDirs: [dir],
+        requirementsFile: req,
+      });
+
+      fs.writeFileSync(req, "pydantic==2.2.0\n");
+
+      expect(
+        _computeSourceHash({ srcDirs: [dir], requirementsFile: req }),
+      ).not.toEqual(before);
+    });
+
+    it("distinguishes a missing requirements file from none at all", () => {
+      const dir = srcDir("a", { "mod.py": "x = 1" });
+
+      expect(
+        _computeSourceHash({
+          srcDirs: [dir],
+          requirementsFile: path.join(root, "absent.txt"),
+        }),
+      ).not.toEqual(_computeSourceHash({ srcDirs: [dir] }));
+    });
+  });
+});


### PR DESCRIPTION
Split from #19 (6/11). Fixes #10.

bundlePython's asset hash omitted pipDeps, non-.py files, and the target architecture, so stale Lambda bundles were silently reused across deploys. The hash now covers every input that shapes the bundle.

File-disjoint from every other PR in the split.
