### PR TITLE
fix(serve): release the Bedrock stream worker when abandoned

### DIFF
--- a/packages/context-manager/src/coa_serve/clients/bedrock.py
+++ b/packages/context-manager/src/coa_serve/clients/bedrock.py
@@ -272,11 +272,20 @@ class BedrockLLMClient:
         queue: asyncio.Queue[str | None | Exception | tuple] = asyncio.Queue()
         loop = asyncio.get_running_loop()
 
-        # Published by the worker as soon as the EventStream exists, so the
-        # event-loop side can close it. Closing the stream is what actually
-        # unblocks the worker's synchronous `for event in ...` — there is no other
-        # cancellation path into a thread-pool thread.
+        # Shared state between the event loop and the worker thread.
+        #
+        # ``stream`` is published by the worker as soon as the EventStream exists so
+        # this side can close it — closing is what unblocks the worker's synchronous
+        # `for event in ...`, since a thread-pool thread has no cancellation point.
+        #
+        # ``abandoned`` covers the window BEFORE that: the ConverseStream API call
+        # itself takes time, and a client that disconnects during it would find
+        # nothing to close, leaving the worker to drain the whole response (holding
+        # an executor slot and billing tokens) for a caller that is already gone.
+        # The worker checks the flag right after the call returns, and again on each
+        # event, so it exits at the first opportunity either way.
         stream_holder: dict[str, Any] = {}
+        abandoned = threading.Event()
 
         def _run_stream() -> None:
             """Run in thread — iterate EventStream, push text chunks to queue."""
@@ -286,7 +295,15 @@ class BedrockLLMClient:
                 client = self._get_client()
                 response = self._call_with_temperature_fallback(client.converse_stream, kwargs)
                 stream_holder["stream"] = response["stream"]
+                if abandoned.is_set():
+                    # Disconnected while the API call was in flight — nothing was
+                    # closeable at that point, so honour the request here.
+                    _close_stream_quietly(response["stream"])
+                    return
                 for event in response["stream"]:
+                    if abandoned.is_set():
+                        _close_stream_quietly(response["stream"])
+                        return
                     if "contentBlockDelta" in event:
                         text = event["contentBlockDelta"].get("delta", {}).get("text", "")
                         if text:
@@ -345,10 +362,14 @@ class BedrockLLMClient:
             # at the `yield`, and suspending on an await inside the resulting
             # `finally` makes CPython raise "async generator ignored GeneratorExit".
             #
-            # Instead: close the stream from this side to unblock the thread, then
-            # detach the worker with a done-callback that surfaces any error. The
-            # generator finalizes synchronously, and the worker cannot keep consuming
-            # the Bedrock stream (and billing tokens) after the client is gone.
+            # Instead: signal the worker to stop, close the stream from this side to
+            # unblock it, then detach it with a done-callback that surfaces any
+            # error. The generator finalizes synchronously, and the worker cannot
+            # keep consuming the Bedrock stream (and billing tokens) after the
+            # client is gone. Setting the flag as well as closing covers the window
+            # where the API call has not returned yet, so there is no stream to
+            # close — see the comment on ``abandoned``.
+            abandoned.set()
             _close_stream_quietly(stream_holder.get("stream"))
             task.add_done_callback(_log_detached_worker_result)
 

--- a/packages/context-manager/src/coa_serve/clients/bedrock.py
+++ b/packages/context-manager/src/coa_serve/clients/bedrock.py
@@ -61,6 +61,40 @@ def _assessment_has_block(assessment: dict) -> bool:
         return False
 
 
+def _close_stream_quietly(stream: Any) -> None:
+    """Close a boto3 EventStream, ignoring absence and close errors.
+
+    Closing the underlying HTTP response is the only way to unblock a worker thread
+    parked in ``for event in stream``: a thread-pool thread has no cancellation
+    point. Best-effort by design — this runs during generator finalization, where
+    raising would mask the original outcome.
+    """
+    if stream is None:
+        return
+    close = getattr(stream, "close", None)
+    if close is None:
+        return
+    try:
+        close()
+    except Exception as exc:  # noqa: BLE001 - finalization must not raise
+        logger.debug("bedrock_stream_close_failed", error=type(exc).__name__, error_msg=str(exc))
+
+
+def _log_detached_worker_result(task: Any) -> None:
+    """Surface a detached stream worker's failure instead of discarding it.
+
+    Attached as a done-callback once the generator stops awaiting the worker, so an
+    exception raised after detachment is still visible rather than swallowed by the
+    unretrieved-result warning.
+    """
+    try:
+        task.result()
+    except asyncio.CancelledError:  # pragma: no cover - normal on shutdown
+        pass
+    except Exception as exc:  # noqa: BLE001 - diagnostics only
+        logger.debug("bedrock_stream_worker_after_detach", error=type(exc).__name__, error_msg=str(exc))
+
+
 class BedrockLLMClient:
     """Bedrock Converse API + embeddings client (Cohere Embed v4 by default)."""
 
@@ -180,7 +214,10 @@ class BedrockLLMClient:
         if not text_blocks:
             raise ValueError(f"No text content in Bedrock response: stopReason={stop_reason}")
 
-        text = text_blocks[0]
+        # Join ALL text blocks. The Converse API may split a response across several
+        # content blocks; taking only the first silently truncated the generation
+        # (and for NL→SQL / NL→SPARQL that means a query cut off mid-statement).
+        text = "".join(text_blocks)
         blocked = False
 
         # Parse guardrail trace to distinguish BLOCK from ANONYMIZE.
@@ -235,6 +272,12 @@ class BedrockLLMClient:
         queue: asyncio.Queue[str | None | Exception | tuple] = asyncio.Queue()
         loop = asyncio.get_running_loop()
 
+        # Published by the worker as soon as the EventStream exists, so the
+        # event-loop side can close it. Closing the stream is what actually
+        # unblocks the worker's synchronous `for event in ...` — there is no other
+        # cancellation path into a thread-pool thread.
+        stream_holder: dict[str, Any] = {}
+
         def _run_stream() -> None:
             """Run in thread — iterate EventStream, push text chunks to queue."""
             guardrail_triggered = False
@@ -242,6 +285,7 @@ class BedrockLLMClient:
             try:
                 client = self._get_client()
                 response = self._call_with_temperature_fallback(client.converse_stream, kwargs)
+                stream_holder["stream"] = response["stream"]
                 for event in response["stream"]:
                     if "contentBlockDelta" in event:
                         text = event["contentBlockDelta"].get("delta", {}).get("text", "")
@@ -289,7 +333,24 @@ class BedrockLLMClient:
         except TimeoutError:
             pending_exception = TimeoutError("Bedrock stream timed out waiting for next token")
         finally:
-            await task
+            # Do NOT await the worker here.
+            #
+            # The worker iterates boto3's SYNCHRONOUS EventStream in a thread-pool
+            # thread and has no cancellation point, so awaiting it blocked for up to
+            # BEDROCK_READ_TIMEOUT (120s) more — which defeated the 300s idle-timeout
+            # guard above: it fired, then this line waited again.
+            #
+            # Worse, on early generator close (the SSE consumer in main.py cancelling
+            # resolve_task when the client disconnects) `GeneratorExit` is thrown in
+            # at the `yield`, and suspending on an await inside the resulting
+            # `finally` makes CPython raise "async generator ignored GeneratorExit".
+            #
+            # Instead: close the stream from this side to unblock the thread, then
+            # detach the worker with a done-callback that surfaces any error. The
+            # generator finalizes synchronously, and the worker cannot keep consuming
+            # the Bedrock stream (and billing tokens) after the client is gone.
+            _close_stream_quietly(stream_holder.get("stream"))
+            task.add_done_callback(_log_detached_worker_result)
 
         if pending_exception:
             raise pending_exception

--- a/packages/context-manager/tests/unit/test_bedrock.py
+++ b/packages/context-manager/tests/unit/test_bedrock.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 from unittest.mock import MagicMock
 
 import pytest
@@ -586,6 +588,72 @@ class TestConverseStreamCleanup:
         client = self._client_over(iter(events))
 
         assert [t async for t in client.converse_stream("q")] == ["a", "b"]
+
+    async def test_abandon_during_the_api_call_still_releases_the_worker(self):
+        """The window before the EventStream exists.
+
+        `converse_stream` (the boto3 call) takes time; a client disconnecting during
+        it finds nothing to close, so the worker would drain the entire response —
+        holding an executor slot and billing tokens for a caller already gone. The
+        `abandoned` flag covers that window.
+        """
+        import threading
+        import time
+
+        closed = threading.Event()
+        drained_fully = threading.Event()
+
+        class _Stream:
+            def __iter__(self):
+                for _ in range(40):
+                    if closed.is_set():
+                        raise RuntimeError("closed")
+                    time.sleep(0.02)
+                drained_fully.set()
+                yield {"contentBlockDelta": {"delta": {"text": "late"}}}
+
+            def close(self):
+                closed.set()
+
+        def _slow_api(**_kwargs):
+            time.sleep(0.3)  # API in flight — nothing closeable yet
+            return {"stream": _Stream()}
+
+        from coa_serve.clients.bedrock import BedrockLLMClient
+
+        mock_client = MagicMock()
+        mock_client.converse_stream = _slow_api
+        client = BedrockLLMClient(model_id="test-model", region="us-east-1")
+        client._client = mock_client
+
+        agen = client.converse_stream("q")
+        pending = asyncio.ensure_future(agen.__anext__())
+        await asyncio.sleep(0.05)  # disconnect BEFORE the API returns
+        pending.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await pending
+        await agen.aclose()
+
+        # The worker sees the flag right after the API call returns.
+        for _ in range(50):
+            if closed.is_set():
+                break
+            await asyncio.sleep(0.05)
+
+        assert closed.is_set(), "worker kept the stream open after the caller left"
+        assert not drained_fully.is_set(), "worker drained the whole response for a gone caller"
+
+    async def test_normal_completion_is_not_treated_as_abandoned(self):
+        """The flag must not fire on the healthy path and truncate the stream."""
+        events = [
+            {"contentBlockDelta": {"delta": {"text": "a"}}},
+            {"contentBlockDelta": {"delta": {"text": "b"}}},
+            {"contentBlockDelta": {"delta": {"text": "c"}}},
+            {"messageStop": {"stopReason": "end_turn"}},
+        ]
+        client = self._client_over(iter(events))
+
+        assert [t async for t in client.converse_stream("q")] == ["a", "b", "c"]
 
     async def test_stream_without_close_method_is_tolerated(self):
         """A plain iterator has no close(); finalization must still not raise."""

--- a/packages/context-manager/tests/unit/test_bedrock.py
+++ b/packages/context-manager/tests/unit/test_bedrock.py
@@ -459,6 +459,143 @@ class TestBedrockConverseStream:
 
 
 @pytest.mark.unit
+class TestConverseMultipleTextBlocks:
+    """The Converse API may split a response across several content blocks."""
+
+    async def test_all_text_blocks_are_joined(self):
+        from coa_serve.clients.bedrock import BedrockLLMClient
+
+        mock_client = MagicMock()
+        mock_client.converse.return_value = {
+            "output": {
+                "message": {
+                    "content": [
+                        {"text": "SELECT ?claim WHERE {"},
+                        {"text": " ?claim a :Claim }"},
+                    ]
+                }
+            }
+        }
+        client = BedrockLLMClient(model_id="test-model", region="us-east-1")
+        client._client = mock_client
+
+        result = await client.converse("q")
+
+        assert result.text == "SELECT ?claim WHERE { ?claim a :Claim }", (
+            "blocks after the first were dropped, truncating the generation"
+        )
+
+    async def test_non_text_blocks_are_still_skipped(self):
+        from coa_serve.clients.bedrock import BedrockLLMClient
+
+        mock_client = MagicMock()
+        mock_client.converse.return_value = {
+            "output": {
+                "message": {
+                    "content": [
+                        {"text": "a"},
+                        {"toolUse": {"name": "x"}},
+                        {"text": "b"},
+                    ]
+                }
+            }
+        }
+        client = BedrockLLMClient(model_id="test-model", region="us-east-1")
+        client._client = mock_client
+
+        assert (await client.converse("q")).text == "ab"
+
+
+@pytest.mark.unit
+class TestConverseStreamCleanup:
+    """Generator finalization must not block on the uncancellable worker thread.
+
+    The worker iterates boto3's synchronous EventStream in a thread-pool thread, so
+    there is no cancellation point: `await task` in `finally` waited out
+    BEDROCK_READ_TIMEOUT, defeating the idle-timeout guard, and on early close it
+    suspended inside GeneratorExit handling — which CPython rejects for async
+    generators ("async generator ignored GeneratorExit").
+    """
+
+    class _BlockingStream:
+        """Emits one chunk, then blocks like boto3's EventStream until closed."""
+
+        def __init__(self, ticks: int = 200, tick_s: float = 0.05):
+            self.closed = False
+            self._ticks = ticks
+            self._tick_s = tick_s
+
+        def __iter__(self):
+            import time
+
+            yield {"contentBlockDelta": {"delta": {"text": "hello"}}}
+            for _ in range(self._ticks):
+                if self.closed:
+                    raise RuntimeError("stream closed")
+                time.sleep(self._tick_s)
+
+        def close(self):
+            self.closed = True
+
+    def _client_over(self, stream):
+        from coa_serve.clients.bedrock import BedrockLLMClient
+
+        mock_client = MagicMock()
+        mock_client.converse_stream.return_value = {"stream": stream}
+        client = BedrockLLMClient(model_id="test-model", region="us-east-1")
+        client._client = mock_client
+        return client
+
+    async def test_early_close_returns_promptly(self):
+        import time
+
+        stream = self._BlockingStream()
+        agen = self._client_over(stream).converse_stream("q")
+
+        assert await agen.__anext__() == "hello"
+        started = time.monotonic()
+        await agen.aclose()
+        elapsed = time.monotonic() - started
+
+        assert elapsed < 2.0, f"aclose() blocked for {elapsed:.1f}s waiting on the worker thread"
+
+    async def test_early_close_closes_the_upstream_stream(self):
+        """Otherwise the worker keeps consuming Bedrock (and billing) after disconnect."""
+        stream = self._BlockingStream()
+        agen = self._client_over(stream).converse_stream("q")
+
+        await agen.__anext__()
+        await agen.aclose()
+
+        assert stream.closed
+
+    async def test_early_close_does_not_raise(self):
+        stream = self._BlockingStream()
+        agen = self._client_over(stream).converse_stream("q")
+
+        await agen.__anext__()
+        await agen.aclose()  # must not raise "async generator ignored GeneratorExit"
+
+    async def test_normal_completion_still_yields_every_token(self):
+        """The detached-worker change must not truncate a healthy stream."""
+        events = [
+            {"contentBlockDelta": {"delta": {"text": "a"}}},
+            {"contentBlockDelta": {"delta": {"text": "b"}}},
+            {"messageStop": {"stopReason": "end_turn"}},
+        ]
+        client = self._client_over(iter(events))
+
+        assert [t async for t in client.converse_stream("q")] == ["a", "b"]
+
+    async def test_stream_without_close_method_is_tolerated(self):
+        """A plain iterator has no close(); finalization must still not raise."""
+        agen = self._client_over(iter([{"contentBlockDelta": {"delta": {"text": "x"}}}])).converse_stream("q")
+
+        assert await agen.__anext__() == "x"
+        await agen.aclose()
+
+
+@pytest.mark.unit
 class TestModelIdValidation:
     def test_validate_rejects_empty(self):
         from coa_serve.model_validation import validate_model_id


### PR DESCRIPTION
Split from #19 (7/11). Fixes #11.

converse_stream's timeout/cancel paths blocked generator finalization on an uncancellable worker thread (GeneratorExit violation), and the worker leaked when the stream was abandoned mid-API-call. Finalization no longer blocks on the worker, and the worker is released when abandoned. Also fixes converse() dropping all but the first text block.

File-disjoint from every other PR in the split.
