### PR TITLE
fix(scripts): finish the SCL_PREFIX default migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ deploy-serve:
 ## deletes VKG's ECS services, force-deletes the DataZone domain (cascades
 ## to RETAINed child resources CFN can't clear on its own), then runs
 ## `cdk destroy --all` and verifies no stacks remain (see #660, #661, #707).
-## Optional env vars: SCL_PREFIX (default: scl), SCL_DESTROY_YES=1 to skip
+## Optional env vars: SCL_PREFIX (default: coa — matches the CDK app), SCL_DESTROY_YES=1 to skip
 ## the confirmation prompt (e.g. in CI), SCL_ENI_WAIT_MAX_SECONDS (default
 ## 600), SCL_ECS_WAIT_MAX_SECONDS (default 300), and
 ## SCL_DOMAIN_WAIT_MAX_SECONDS (default 300) to tune wait budgets.

--- a/infra/lib/constructs/scl-stack.ts
+++ b/infra/lib/constructs/scl-stack.ts
@@ -9,7 +9,7 @@ import { resolveContext, prefixed } from "../context";
  * Base stack for all SemanticContext CloudFormation stacks.
  *
  * ## CDK Context Variables
- *   - `resource_prefix` (default: `"scl"`)
+ *   - `resource_prefix` (default: `DEFAULT_RESOURCE_PREFIX`, i.e. `"coa"`)
  *   - `env`             (default: `"dev"`)
  *   - `project_tag`     (default: `"semantic-context"`)
  *   - `vpc_id`          (optional, on NetworkStack - import existing VPC)

--- a/scripts/deploy-serve.sh
+++ b/scripts/deploy-serve.sh
@@ -22,7 +22,11 @@ set -euo pipefail
 #   IMAGE_TAG=v1.2.3 ./scripts/deploy-serve.sh
 
 ENV="${1:-dev}"
-PREFIX="${SCL_PREFIX:-scl}"
+# Default MUST match the CDK app's DEFAULT_RESOURCE_PREFIX
+# (libs/ts-shared/src/constants.ts, resolved in infra/lib/context.ts).
+# A mismatch means this script resolves scl-* names / /scl SSM parameters
+# while `cdk` operates on coa-* — every lookup silently misses.
+PREFIX="${SCL_PREFIX:-coa}"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 ECR_REPO="${PREFIX}-${ENV}-context-manager"
@@ -105,32 +109,47 @@ RUNTIME_ARN=$(aws cloudformation describe-stacks \
   --query 'Stacks[0].Outputs[?OutputKey==`AgentRuntimeArn`].OutputValue' \
   --output text 2>/dev/null || echo "")
 
-ENDPOINT_NAME=$(aws cloudformation describe-stacks \
-  --stack-name "${PREFIX}-${ENV}-serve" \
-  --query 'Stacks[0].Outputs[?OutputKey==`AgentRuntimeEndpointName`].OutputValue' \
-  --output text 2>/dev/null || echo "")
+# The serve stack exports AgentRuntimeArn / AgentRuntimeId / AgentRuntimeName —
+# there is no AgentRuntimeEndpointName output. Reading it always yielded an empty
+# qualifier, and because every failure below was redirected to /dev/null the smoke
+# test "passed" while verifying nothing. DEFAULT is the qualifier AgentCore
+# creates alongside a runtime.
+ENDPOINT_NAME="${AGENT_RUNTIME_QUALIFIER:-DEFAULT}"
 
-if [ -n "${RUNTIME_ARN}" ] && [ "${RUNTIME_ARN}" != "None" ]; then
-  HEALTH_PAYLOAD=$(mktemp)
-  RESPONSE_FILE=$(mktemp)
-  echo '{"query":"ping","namespace":"smoke-test"}' > "${HEALTH_PAYLOAD}"
+if [ -z "${RUNTIME_ARN}" ] || [ "${RUNTIME_ARN}" = "None" ]; then
+  echo "  FAILED: stack ${PREFIX}-${ENV}-serve has no AgentRuntimeArn output" >&2
+  exit 1
+fi
 
-  # Allow warm-up time — retry up to 3 times
-  for attempt in 1 2 3; do
-    if aws bedrock-agentcore invoke-agent-runtime \
-      --agent-runtime-arn "${RUNTIME_ARN}" \
-      --qualifier "${ENDPOINT_NAME}" \
-      --content-type "application/json" \
-      --payload "fileb://${HEALTH_PAYLOAD}" \
-      "${RESPONSE_FILE}" > /dev/null 2>&1; then
-      echo "  Health: $(cat "${RESPONSE_FILE}")"
-      break
-    fi
-    [ "${attempt}" -lt 3 ] && sleep 10
-  done
-  rm -f "${HEALTH_PAYLOAD}" "${RESPONSE_FILE}"
-else
-  echo "  Skipped (no AgentRuntimeArn output)"
+HEALTH_PAYLOAD=$(mktemp)
+RESPONSE_FILE=$(mktemp)
+INVOKE_LOG=$(mktemp)
+echo '{"query":"ping","namespace":"smoke-test"}' > "${HEALTH_PAYLOAD}"
+
+SMOKE_OK=0
+# Allow warm-up time — retry up to 3 times
+for attempt in 1 2 3; do
+  if aws bedrock-agentcore invoke-agent-runtime \
+    --agent-runtime-arn "${RUNTIME_ARN}" \
+    --qualifier "${ENDPOINT_NAME}" \
+    --content-type "application/json" \
+    --payload "fileb://${HEALTH_PAYLOAD}" \
+    "${RESPONSE_FILE}" > "${INVOKE_LOG}" 2>&1; then
+    echo "  Health: $(cat "${RESPONSE_FILE}")"
+    SMOKE_OK=1
+    break
+  fi
+  echo "  attempt ${attempt}/3 failed: $(tail -n 3 "${INVOKE_LOG}")" >&2
+  [ "${attempt}" -lt 3 ] && sleep 10
+done
+
+rm -f "${HEALTH_PAYLOAD}" "${RESPONSE_FILE}" "${INVOKE_LOG}"
+
+# Fail loudly. A deploy script whose verification cannot fail is not a
+# verification.
+if [ "${SMOKE_OK}" -ne 1 ]; then
+  echo "  FAILED: smoke test could not invoke the runtime after 3 attempts" >&2
+  exit 1
 fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────

--- a/scripts/deploy-serve.sh
+++ b/scripts/deploy-serve.sh
@@ -99,58 +99,57 @@ pnpm --filter coa-infra exec cdk deploy "${PREFIX}-${ENV}-serve" \
   ${CONTEXT} \
   ${APPROVAL}
 
-# ── Smoke Test ───────────────────────────────────────────────────────────────
+# ── Post-deploy check ────────────────────────────────────────────────────────
+#
+# This deliberately does NOT invoke the runtime. The runtime is created with
+# `RuntimeAuthorizerConfiguration.usingJWT(...)` (serve-stack.ts), so it accepts
+# only a bearer ID token from the configured IdP — a SigV4
+# `aws bedrock-agentcore invoke-agent-runtime` is rejected no matter how long the
+# runtime has been warm. The previous version of this block appeared to invoke the
+# runtime but read a CFN output that does not exist (`AgentRuntimeEndpointName`,
+# while the stack exports AgentRuntimeArn / Id / Name), so the qualifier was always
+# empty and every failure was redirected to /dev/null — it "passed" while verifying
+# nothing.
+#
+# Rather than fake an invocation, assert what can actually be checked without a
+# user token: the runtime exists and reached a READY state. An end-to-end query
+# needs an ID token and belongs in the integ suite (`make test-integ`), not here.
 
 echo ""
-echo "--- Smoke test ---"
+echo "--- Post-deploy check ---"
 
 RUNTIME_ARN=$(aws cloudformation describe-stacks \
   --stack-name "${PREFIX}-${ENV}-serve" \
   --query 'Stacks[0].Outputs[?OutputKey==`AgentRuntimeArn`].OutputValue' \
   --output text 2>/dev/null || echo "")
 
-# The serve stack exports AgentRuntimeArn / AgentRuntimeId / AgentRuntimeName —
-# there is no AgentRuntimeEndpointName output. Reading it always yielded an empty
-# qualifier, and because every failure below was redirected to /dev/null the smoke
-# test "passed" while verifying nothing. DEFAULT is the qualifier AgentCore
-# creates alongside a runtime.
-ENDPOINT_NAME="${AGENT_RUNTIME_QUALIFIER:-DEFAULT}"
-
 if [ -z "${RUNTIME_ARN}" ] || [ "${RUNTIME_ARN}" = "None" ]; then
   echo "  FAILED: stack ${PREFIX}-${ENV}-serve has no AgentRuntimeArn output" >&2
   exit 1
 fi
+echo "  Runtime ARN: ${RUNTIME_ARN}"
 
-HEALTH_PAYLOAD=$(mktemp)
-RESPONSE_FILE=$(mktemp)
-INVOKE_LOG=$(mktemp)
-echo '{"query":"ping","namespace":"smoke-test"}' > "${HEALTH_PAYLOAD}"
-
-SMOKE_OK=0
-# Allow warm-up time — retry up to 3 times
+RUNTIME_ID="${RUNTIME_ARN##*/}"
+STATUS=""
 for attempt in 1 2 3; do
-  if aws bedrock-agentcore invoke-agent-runtime \
-    --agent-runtime-arn "${RUNTIME_ARN}" \
-    --qualifier "${ENDPOINT_NAME}" \
-    --content-type "application/json" \
-    --payload "fileb://${HEALTH_PAYLOAD}" \
-    "${RESPONSE_FILE}" > "${INVOKE_LOG}" 2>&1; then
-    echo "  Health: $(cat "${RESPONSE_FILE}")"
-    SMOKE_OK=1
-    break
-  fi
-  echo "  attempt ${attempt}/3 failed: $(tail -n 3 "${INVOKE_LOG}")" >&2
+  STATUS=$(aws bedrock-agentcore-control get-agent-runtime \
+    --agent-runtime-id "${RUNTIME_ID}" \
+    --query 'status' --output text 2>/dev/null || echo "")
+  case "${STATUS}" in
+    READY) break ;;
+    CREATING|UPDATING) echo "  status=${STATUS}, waiting..." ;;
+    "") echo "  could not read runtime status (attempt ${attempt}/3)" >&2 ;;
+    *) echo "  status=${STATUS}" >&2 ;;
+  esac
   [ "${attempt}" -lt 3 ] && sleep 10
 done
 
-rm -f "${HEALTH_PAYLOAD}" "${RESPONSE_FILE}" "${INVOKE_LOG}"
-
-# Fail loudly. A deploy script whose verification cannot fail is not a
-# verification.
-if [ "${SMOKE_OK}" -ne 1 ]; then
-  echo "  FAILED: smoke test could not invoke the runtime after 3 attempts" >&2
+if [ "${STATUS}" != "READY" ]; then
+  echo "  FAILED: runtime ${RUNTIME_ID} is '${STATUS:-unknown}', expected READY" >&2
+  echo "  (an end-to-end query needs an IdP token — see 'make test-integ')" >&2
   exit 1
 fi
+echo "  Runtime status: READY"
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 
@@ -160,14 +159,18 @@ echo "  Stack:    ${PREFIX}-${ENV}-serve"
 echo "  Image:    ${IMAGE_FULL}"
 if [ -n "${RUNTIME_ARN}" ] && [ "${RUNTIME_ARN}" != "None" ]; then
   echo "  Runtime:  ${RUNTIME_ARN}"
-  echo "  Endpoint: ${ENDPOINT_NAME}"
   echo ""
-  echo "Invoke with:"
-  echo "  echo '{\"query\":\"...\",\"namespace\":\"...\"}' > payload.json"
-  echo "  aws bedrock-agentcore invoke-agent-runtime \\"
-  echo "    --agent-runtime-arn '${RUNTIME_ARN}' \\"
-  echo "    --qualifier '${ENDPOINT_NAME}' \\"
-  echo "    --content-type 'application/json' \\"
-  echo "    --payload 'fileb://payload.json' \\"
-  echo "    response.json"
+  # The runtime authorizes with JWT (serve-stack.ts), so it needs a bearer ID
+  # token from the configured IdP — a SigV4 `aws bedrock-agentcore
+  # invoke-agent-runtime` is rejected. The previous version of this block
+  # printed exactly that command, which cannot work.
+  echo "Invoke with a bearer ID token from the app's IdP:"
+  echo "  curl -X POST \\"
+  echo "    'https://bedrock-agentcore.${REGION}.amazonaws.com/runtimes/${RUNTIME_ID}/invocations?qualifier=DEFAULT' \\"
+  echo "    -H \"Authorization: Bearer \${ID_TOKEN}\" \\"
+  echo "    -H 'Content-Type: application/json' \\"
+  echo "    -d '{\"query\":\"...\",\"namespace\":\"...\"}'"
+  echo ""
+  echo "Or run the integ suite, which provisions a token for you:"
+  echo "  make test-integ"
 fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -26,7 +26,8 @@ CONTEXT="--context env=$ENV"
 [ -n "${SCL_HOSTED_ZONE_ID:-}" ] && CONTEXT="$CONTEXT --context hosted_zone_id=$SCL_HOSTED_ZONE_ID"
 
 # ── Resolve VPC peering context from test-databases stack (if deployed) ──
-TEST_STACK_NAME="${SCL_PREFIX:-scl}-integ-test-databases"
+# Prefix default matches the CDK app (see DEFAULT_RESOURCE_PREFIX).
+TEST_STACK_NAME="${SCL_PREFIX:-coa}-integ-test-databases"
 if [ -z "${SCL_JDBC_PEER_VPC_ID:-}" ]; then
   SCL_JDBC_PEER_VPC_ID=$(aws cloudformation describe-stacks \
     --stack-name "$TEST_STACK_NAME" \
@@ -43,6 +44,11 @@ if [ -n "${SCL_JDBC_PEER_VPC_ID:-}" ] && [ "$SCL_JDBC_PEER_VPC_ID" != "None" ] \
   && [ -n "${SCL_JDBC_PEER_CIDRS:-}" ] && [ "$SCL_JDBC_PEER_CIDRS" != "None" ]; then
   echo "Peering into test VPC ${SCL_JDBC_PEER_VPC_ID} (${SCL_JDBC_PEER_CIDRS})"
   CONTEXT="$CONTEXT --context jdbc_peer_vpc_id=$SCL_JDBC_PEER_VPC_ID --context jdbc_peer_cidrs=$SCL_JDBC_PEER_CIDRS"
+else
+  # The stack is optional, so skipping is normal — but say so. Silence here is
+  # indistinguishable from a prefix mismatch resolving the wrong stack name, which
+  # is how this went unnoticed while the default was 'scl'.
+  echo "No JDBC peering context (stack ${TEST_STACK_NAME} not found or has no VPC outputs) — skipping"
 fi
 
 # ponytail: CDK_DOCKER selection — only pick Finch if its daemon is actually

--- a/scripts/destroy.sh
+++ b/scripts/destroy.sh
@@ -37,7 +37,11 @@ set -uo pipefail
 ENV="${1:-dev}"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 REGION="${CDK_DEFAULT_REGION:-${AWS_DEFAULT_REGION:-${AWS_REGION:-us-east-1}}}"
-PREFIX="${SCL_PREFIX:-scl}"
+# Default MUST match the CDK app's DEFAULT_RESOURCE_PREFIX
+# (libs/ts-shared/src/constants.ts, resolved in infra/lib/context.ts).
+# A mismatch means this script resolves scl-* names / /scl SSM parameters
+# while `cdk` operates on coa-* — every lookup silently misses.
+PREFIX="${SCL_PREFIX:-coa}"
 STACK_PREFIX="${PREFIX}-${ENV}"
 SSM_PREFIX="/${PREFIX}"
 

--- a/scripts/fetch-runtime-config.sh
+++ b/scripts/fetch-runtime-config.sh
@@ -12,7 +12,11 @@ set -euo pipefail
 
 REGION=""
 PROFILE=""
-PREFIX="scl"
+# Keep in sync with DEFAULT_RESOURCE_PREFIX in libs/ts-shared/src/constants.ts.
+# Defaulting to "scl" while the CDK app defaults to "coa" made this script read
+# outputs from a stack named scl-dev-* that a default deployment never creates,
+# so runtime-config.json came back empty instead of failing loudly.
+PREFIX="${SCL_PREFIX:-coa}"
 ENV="dev"
 
 while [[ $# -gt 0 ]]; do

--- a/scripts/onboard-demo.sh
+++ b/scripts/onboard-demo.sh
@@ -58,7 +58,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 PROFILE=""
 REGION="${AWS_DEFAULT_REGION:-us-west-2}"
-PREFIX="scl"
+# Keep in sync with DEFAULT_RESOURCE_PREFIX in libs/ts-shared/src/constants.ts.
+PREFIX="${SCL_PREFIX:-coa}"
 ENV_NAME="dev"
 INDUSTRY="insurance"
 MANIFEST=""              # explicit manifest path (else demo/$INDUSTRY/manifest.yaml)

--- a/scripts/serve/benchmark/runner.py
+++ b/scripts/serve/benchmark/runner.py
@@ -20,7 +20,7 @@ Usage:
 
 Environment:
     AWS_REGION       (default: us-east-1)
-    SCL_PREFIX       (default: scl)
+    SCL_PREFIX       (default: coa)
     SCL_USERNAME     Cognito username (default: from Secrets Manager)
     SCL_PASSWORD     Cognito password (default: from Secrets Manager)
     BENCH_NS         Namespace override


### PR DESCRIPTION
Split from #19 (8/11). Fixes #12.

Shell scripts defaulted SCL_PREFIX to `scl` while the CDK app defaults to `coa`, so destroy.sh's pre-cleanup silently no-oped against real stacks. Scripts now share the `coa` default, and the runtime-readiness check probes runtime state instead of faking an invocation.

File-disjoint from every other PR in the split.
