### PR TITLE
fix(ontology): table IRI identity, FK parsing, composite-FK R2RML

### DIFF
--- a/packages/ontology-engine/src/coa_ontology/induce_catalog.py
+++ b/packages/ontology-engine/src/coa_ontology/induce_catalog.py
@@ -122,9 +122,12 @@ def _compute_structural_fingerprint(tables) -> str:
     import hashlib
 
     def _norm_ref(ref: str) -> str:
-        # Keep only the trailing table.column (drop catalog/db qualifiers).
-        parts = ref.split(".")
-        return ".".join(parts[-2:]) if len(parts) >= 2 else ref
+        # Keep only the trailing table.column (drop catalog/db qualifiers), using
+        # the one shared parser so the fingerprint agrees with every consumer.
+        from coa_ontology.inducer.services.data_catalog import parse_referred_column
+
+        table, column = parse_referred_column(ref)
+        return f"{table}.{column}" if column is not None else table
 
     parts = []
     for t in sorted(tables, key=lambda x: x.name):

--- a/packages/ontology-engine/src/coa_ontology/inducer/services/data_catalog.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/services/data_catalog.py
@@ -34,6 +34,45 @@ class CatalogConstraint(BaseModel):
     relationshipType: str | None = None
 
 
+def parse_referred_column(ref: str) -> tuple[str, str | None]:
+    """Split a ``referredColumns`` entry into ``(target_table, target_column)``.
+
+    The catalog reports an FK target as a dotted identifier whose LAST TWO
+    segments are ``TABLE.COLUMN``. Everything before them is qualification
+    (database, schema, catalog) and is dropped:
+
+        ``"orders.order_id"``               → ``("orders", "order_id")``
+        ``"public.orders.order_id"``        → ``("orders", "order_id")``
+        ``"db.public.orders.order_id"``     → ``("orders", "order_id")``
+        ``"orders"``                        → ``("orders", None)``
+
+    A single-segment value carries no column, so the caller cannot build a
+    join condition from it — ``build_r2rml`` treats that as a plain datatype
+    column rather than emitting a bare ``rr:parentTriplesMap``, which would make
+    Ontop produce a Cartesian product (R2RML §7.5).
+
+    This lives here, next to :class:`CatalogConstraint`, because the rule was
+    previously re-implemented at six call sites under TWO INCOMPATIBLE
+    conventions: ``parts[0]`` in the R2RML builder and the RIGOR topological sort,
+    ``parts[-2]`` in the ontology builder, the SHACL config generator, the subtype
+    detector, and the fingerprint normalizer. For a three-part reference the
+    former yields the SCHEMA name, so the mapping pointed ``rr:parentTriplesMap``
+    at a TriplesMap that does not exist while the ontology and shapes correctly
+    referenced the table — the artifacts described different graphs.
+
+    Args:
+        ref: A ``referredColumns`` entry.
+
+    Returns:
+        ``(target_table, target_column)``; ``target_column`` is ``None`` when
+        ``ref`` has no dot.
+    """
+    parts = ref.split(".")
+    if len(parts) >= 2:
+        return parts[-2], parts[-1]
+    return ref, None
+
+
 class CatalogTable(BaseModel):
     """A table from the data catalog, with its columns, constraints, and datasource."""
 

--- a/packages/ontology-engine/src/coa_ontology/inducer/services/subtype_detection.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/services/subtype_detection.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import logging
 
-from coa_ontology.inducer.services.data_catalog import CatalogTable
+from coa_ontology.inducer.services.data_catalog import CatalogTable, parse_referred_column
 
 logger = logging.getLogger(__name__)
 
@@ -55,11 +55,9 @@ def _single_col_fks(table: CatalogTable) -> list[tuple[str, str, str]]:
             continue
         if not tc.referredColumns or len(tc.referredColumns) != 1:
             continue
-        parts = tc.referredColumns[0].split(".")
-        if len(parts) < 2:
-            continue
-        parent_table = parts[-2]
-        parent_col = parts[-1]
+        parent_table, parent_col = parse_referred_column(tc.referredColumns[0])
+        if parent_col is None:
+            continue  # no column component — cannot match against the parent PK
         fks.append((tc.columns[0], parent_table, parent_col))
     return fks
 

--- a/packages/ontology-engine/src/coa_ontology/inducer/strategies/base.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/strategies/base.py
@@ -5,9 +5,11 @@
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import re
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 
 from coa_common import sql_ident
 from coa_common.bedrock_metrics import CostTracker
@@ -152,6 +154,76 @@ def to_camel(s: str) -> str:
     return p[0].lower() + p[1:] if p else p
 
 
+def _name_discriminator(name: str) -> str:
+    """Return a short deterministic suffix distinguishing ``name`` from its peers.
+
+    Derived from the verbatim name, so it is stable across runs (no hashing of
+    iteration order or object identity) and identical in every consumer that
+    mints IRIs for the same table.
+    """
+    return hashlib.sha256(name.encode("utf-8")).hexdigest()[:8]
+
+
+def pascal_names_for(names: Iterable[str]) -> dict[str, str]:
+    r"""Map each verbatim table name to a COLLISION-FREE PascalCase local name.
+
+    :func:`to_pascal` is lossy: it strips every character outside
+    ``[a-zA-Z0-9\s_\-]``, treats space/underscore/hyphen as one separator
+    class, and normalizes case. So ``order_item``, ``order-item``,
+    ``Order_Item``, and ``ORDER ITEM`` all collapse onto ``OrderItem``, and any
+    name made entirely of stripped characters collapses onto the ``"Entity"``
+    fallback. Minting class / TriplesMap IRIs straight from ``to_pascal`` therefore
+    silently FUSES distinct source tables onto one IRI: one class carrying both
+    tables' labels, key axioms, and cardinality restrictions, and — worse — one
+    TriplesMap carrying two ``rr:logicalTable`` / ``rr:tableName`` values, which
+    is invalid R2RML (a TriplesMap has exactly one logical table). Ontop then
+    either rejects the whole mapping (VKG load fails for the namespace) or picks
+    one table non-deterministically and drops the other's data.
+
+    This helper resolves collisions instead: the first name (in the caller's
+    order) keeps the bare PascalCase form so existing single-table-per-name
+    deployments mint byte-identical IRIs, and each subsequent colliding name gets
+    ``{Pascal}_{sha256(name)[:8]}`` appended. The discriminator is derived from
+    the verbatim name, so the assignment is deterministic given the same input
+    order and is reproducible across the ontology builder, the R2RML builder, and
+    the SHACL config generator — all three must agree or the artifacts diverge.
+
+    Callers should also surface a collision to the user (see the ``log.warning``
+    below): a silent merge is the worst of the possible outcomes, and a schema
+    that needs a discriminator usually indicates a naming problem worth fixing at
+    the source.
+
+    Args:
+        names: Verbatim table names, in a stable order.
+
+    Returns:
+        ``{verbatim_name: unique_pascal_local_name}`` covering every input name.
+    """
+    result: dict[str, str] = {}
+    taken: set[str] = set()
+    for name in names:
+        if name in result:
+            continue  # duplicate entry for the same table — one mapping is enough
+        base = to_pascal(name)
+        candidate = base
+        if candidate in taken:
+            candidate = f"{base}_{_name_discriminator(name)}"
+            log.warning(
+                "table_name_collides_after_pascal_case",
+                extra={"table": name, "collided_on": base, "minted": candidate},
+            )
+            # Pathological: the discriminated form is itself taken (two tables
+            # with the same verbatim name would have been deduped above, so this
+            # needs a genuine hash collision). Widen until unique.
+            suffix = 2
+            while candidate in taken:
+                candidate = f"{base}_{_name_discriminator(name)}_{suffix}"
+                suffix += 1
+        taken.add(candidate)
+        result[name] = candidate
+    return result
+
+
 def _annotate_triples_map(g: Graph, tmap: URIRef, table: CatalogTable) -> None:
     """Annotate a TriplesMap with datasource provenance (coa:datasourceId, coa:sourceSchema).
 
@@ -254,14 +326,22 @@ class InductionStrategy(ABC):
         g.bind("ind", ns)
         g.bind("xsd", XSD)
 
-        # Build a lookup from table name → TriplesMap URI for parentTriplesMap refs
+        # Build a lookup from table name → TriplesMap URI for parentTriplesMap refs.
+        # Local names come from the collision-resolving helper, not bare
+        # to_pascal: two tables differing only in separators/case would otherwise
+        # share one TriplesMap IRI and produce two rr:tableName values on it
+        # (invalid R2RML — see pascal_names_for).
+        pascal_by_name = pascal_names_for(t.name for t in tables)
+        # Property local names derive from the (possibly discriminated) class
+        # local name, so a disambiguated class carries disambiguated predicates.
+        camel_by_name = {n: p[0].lower() + p[1:] if p else p for n, p in pascal_by_name.items()}
         tmap_by_name: dict[str, URIRef] = {}
         for table in tables:
-            tmap_by_name[table.name] = ns[f"TriplesMap_{to_pascal(table.name)}"]
+            tmap_by_name[table.name] = ns[f"TriplesMap_{pascal_by_name[table.name]}"]
 
         for table in tables:
             tmap = tmap_by_name[table.name]
-            table_cls = ns[to_pascal(table.name)]
+            table_cls = ns[pascal_by_name[table.name]]
 
             g.add((tmap, RDF.type, RR.TriplesMap))
             _annotate_triples_map(g, tmap, table)
@@ -311,7 +391,7 @@ class InductionStrategy(ABC):
                 pom = URIRef(f"{tmap}/POM_{to_pascal(col.name)}")
                 g.add((tmap, RR.predicateObjectMap, pom))
 
-                prop_uri = ns[f"{to_camel(table.name)}_{to_camel(col.name)}"]
+                prop_uri = ns[f"{camel_by_name[table.name]}_{to_camel(col.name)}"]
                 g.add((pom, RR.predicate, prop_uri))
 
                 om = URIRef(f"{pom}/ObjectMap")
@@ -363,6 +443,10 @@ class InductionStrategy(ABC):
                     fk_target = composite_fk.referredColumns[0].split(".")[0]
                     parent_tmap = tmap_by_name.get(fk_target)
                     if parent_tmap is None:
+                        # Target table is outside this induction run, so it has no
+                        # entry in pascal_by_name. Fall back to the bare form —
+                        # nothing to collide with here, since a table we did not
+                        # process has no TriplesMap in this mapping either.
                         parent_tmap = ns[f"TriplesMap_{to_pascal(fk_target)}"]
 
                     g.add((om, RR.parentTriplesMap, parent_tmap))

--- a/packages/ontology-engine/src/coa_ontology/inducer/strategies/base.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/strategies/base.py
@@ -224,6 +224,81 @@ def pascal_names_for(names: Iterable[str]) -> dict[str, str]:
     return result
 
 
+def composite_fk_is_usable(tc) -> bool:
+    """True when a composite FK constraint can produce a valid Referencing Object Map.
+
+    :meth:`InductionStrategy.build_r2rml` degrades a composite FK to plain datatype
+    ObjectMaps when it is malformed — ``columns`` / ``referredColumns`` of unequal
+    length (no way to pair them into join conditions), or ``referredColumns``
+    spanning several target tables (a TriplesMap has one parent). The ontology
+    builder must apply the SAME test, or it declares an ``owl:ObjectProperty`` with
+    ``rdfs:range <ParentClass>`` for a column the mapping exposes as a string or
+    integer literal: ``rdfs:range`` and ``rr:datatype`` then disagree, and Ontop's
+    type reasoning drops the triples or fails the SPARQL type filter.
+    """
+    if tc.constraintType != "FOREIGN_KEY" or not tc.referredColumns or len(tc.columns or []) <= 1:
+        return False
+    if len(tc.columns) != len(tc.referredColumns):
+        return False
+    fk_tables = {rc.split(".")[0] for rc in tc.referredColumns if "." in rc}
+    return len(fk_tables) <= 1
+
+
+def composite_fk_columns(table: CatalogTable) -> dict[str, str]:
+    """Map each column absorbed into a composite-FK POM to the column that owns it.
+
+    A composite (multi-column) FK is expressed in R2RML as ONE Referencing Object
+    Map carrying one ``rr:joinCondition`` per column pair (§7.5) — not one map per
+    column. :meth:`InductionStrategy.build_r2rml` therefore emits a single POM,
+    anchored on the constraint's FIRST column, and emits nothing for the rest.
+
+    The ontology builder must know which columns those are. Declaring an
+    ``owl:ObjectProperty`` per participating column (the obvious reading of the
+    constraint) mints properties that have no POM behind them: they appear in the
+    published TBox, in the class/property browser, and in the TBox context handed
+    to the NL→SPARQL LLM, so the model is actively encouraged to author SPARQL
+    against a property Ontop cannot resolve to any column. The query compiles and
+    returns nothing, with no mapping-gap signal in the logs. The gap scales with
+    arity: a 3-column FK orphaned 2 properties.
+
+    A MALFORMED composite FK (see :func:`composite_fk_is_usable`) behaves
+    differently: ``build_r2rml`` gives every one of its columns a datatype
+    ObjectMap, so none is absorbed — but none carries the relationship either, and
+    the ontology must not declare any of them an object property. Those columns map
+    to ``""``, letting the caller distinguish "absorbed into a sibling's POM" from
+    "no relationship at all" while treating both as non-object properties.
+
+    Returns:
+        ``{column: owning_column}`` for columns absorbed into a sibling's POM, plus
+        ``{column: ""}`` for every column of a malformed composite FK. The owning
+        (first) column of a USABLE composite FK is absent — it keeps both its POM
+        and its object property. Empty when the table has no composite FK.
+    """
+    absorbed: dict[str, str] = {}
+    if not table.tableConstraints:
+        return absorbed
+    table_columns = {c.name for c in table.columns}
+    for tc in table.tableConstraints:
+        if tc.constraintType != "FOREIGN_KEY" or not tc.referredColumns or len(tc.columns or []) <= 1:
+            continue
+        if not composite_fk_is_usable(tc):
+            # Degraded to datatype ObjectMaps in the mapping — no object property
+            # for ANY of these columns, the first one included.
+            for col_name in tc.columns:
+                if col_name in table_columns:
+                    absorbed.setdefault(col_name, "")
+            continue
+        # build_r2rml anchors the POM on the first column of the constraint that
+        # the table actually has (it iterates table.columns), so mirror that.
+        owner = next((c for c in table.columns if c.name in tc.columns), None)
+        if owner is None:
+            continue
+        for col_name in tc.columns:
+            if col_name != owner.name and col_name in table_columns:
+                absorbed.setdefault(col_name, owner.name)
+    return absorbed
+
+
 def _annotate_triples_map(g: Graph, tmap: URIRef, table: CatalogTable) -> None:
     """Annotate a TriplesMap with datasource provenance (coa:datasourceId, coa:sourceSchema).
 
@@ -379,13 +454,30 @@ class InductionStrategy(ABC):
                     if tc.constraintType == "FOREIGN_KEY" and tc.referredColumns and len(tc.columns) > 1:
                         composite_fk_constraints.append(tc)
 
-            # Track which columns have already been emitted as part of a composite FK
-            # to avoid emitting duplicate POMs.
-            composite_fk_emitted: set[str] = set()
+            # Columns a USABLE composite FK folds into its owning column's
+            # referencing map. Computed up front (not accumulated while iterating)
+            # so the branch below is independent of column order, and shared with
+            # the ontology builder so both agree on which columns are literals.
+            absorbed_columns = {name for name, owner in composite_fk_columns(table).items() if owner}
 
             for col in table.columns:
-                # Skip columns already emitted as part of a composite FK POM
-                if col.name in composite_fk_emitted:
+                # A column absorbed into a sibling's composite-FK Referencing
+                # Object Map still gets its OWN datatype POM. The relationship is
+                # carried once (by the owning column's referencing map, per R2RML
+                # §7.5) — but the column is a real column, and leaving it unmapped
+                # meant the ontology's declaration for it had nothing behind it, so
+                # any SPARQL touching that property silently returned nothing.
+                # Emitting a literal mapping keeps mapping and ontology in step:
+                # the ontology declares these columns as datatype properties (see
+                # composite_fk_columns).
+                if col.name in absorbed_columns:
+                    pom = URIRef(f"{tmap}/POM_{to_pascal(col.name)}")
+                    g.add((tmap, RR.predicateObjectMap, pom))
+                    g.add((pom, RR.predicate, ns[f"{camel_by_name[table.name]}_{to_camel(col.name)}"]))
+                    om = URIRef(f"{pom}/ObjectMap")
+                    g.add((pom, RR.objectMap, om))
+                    g.add((om, RR.column, Literal(sql_ident(col.name))))
+                    g.add((om, RR.datatype, xsd_for_column(col.dataType, col.name)))
                     continue
 
                 pom = URIRef(f"{tmap}/POM_{to_pascal(col.name)}")
@@ -416,8 +508,6 @@ class InductionStrategy(ABC):
                             len(composite_fk.columns),
                             len(composite_fk.referredColumns),
                         )
-                        for c in composite_fk.columns:
-                            composite_fk_emitted.add(c)
                         composite_fk_constraints.remove(composite_fk)
                         g.add((om, RR.column, Literal(sql_ident(col.name))))
                         dt = xsd_for(col.dataType)
@@ -432,8 +522,6 @@ class InductionStrategy(ABC):
                             table.name,
                             fk_tables,
                         )
-                        for c in composite_fk.columns:
-                            composite_fk_emitted.add(c)
                         composite_fk_constraints.remove(composite_fk)
                         g.add((om, RR.column, Literal(sql_ident(col.name))))
                         dt = xsd_for(col.dataType)
@@ -458,9 +546,6 @@ class InductionStrategy(ABC):
                         g.add((jc, RR.child, Literal(sql_ident(child_col))))
                         g.add((jc, RR.parent, Literal(sql_ident(parent_col))))
 
-                    # Mark all columns in this composite FK as emitted
-                    for c in composite_fk.columns:
-                        composite_fk_emitted.add(c)
                     # Remove from composite list to avoid re-processing
                     composite_fk_constraints.remove(composite_fk)
                     continue

--- a/packages/ontology-engine/src/coa_ontology/inducer/strategies/base.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/strategies/base.py
@@ -158,25 +158,43 @@ def to_camel(s: str) -> str:
     return p[0].lower() + p[1:] if p else p
 
 
-def _name_discriminator(name: str) -> str:
-    """Return a short deterministic suffix distinguishing ``name`` from its peers.
+def _name_discriminator(identity: str) -> str:
+    """Return a short deterministic suffix distinguishing ``identity`` from its peers.
 
-    Derived from the verbatim name, so it is stable across runs (no hashing of
-    iteration order or object identity) and identical in every consumer that
-    mints IRIs for the same table.
+    Derived from the table's verbatim identity (see :func:`table_identity`), so it
+    is stable across runs (no hashing of iteration order or object identity) and
+    identical in every consumer that mints IRIs for the same table.
     """
-    return hashlib.sha256(name.encode("utf-8")).hexdigest()[:8]
+    return hashlib.sha256(identity.encode("utf-8")).hexdigest()[:8]
 
 
-def pascal_names_for(names: Iterable[str]) -> dict[str, str]:
-    r"""Map each verbatim table name to a COLLISION-FREE PascalCase local name.
+def table_identity(table: CatalogTable) -> str:
+    """Return the key that distinguishes ``table`` from every other table in a run.
+
+    ``CatalogTable.name`` is the BARE table name: ``_catalog_to_tables`` fills it
+    from ``tbl["name"]`` and puts the qualified form in ``fullyQualifiedName``. A
+    single induction flattens every database of every requested datasource into one
+    list, so bare names repeat routinely — ``public.customers`` and
+    ``analytics.customers`` are two tables that must stay two classes, two
+    TriplesMaps, and two sets of properties. Keying anything on ``name`` fuses them.
+
+    The qualified name is the identity; the bare name still supplies the *display*
+    form the PascalCase local name is derived from, so a table whose name is unique
+    mints exactly the IRI it minted before.
+    """
+    return table.fullyQualifiedName or table.name
+
+
+def pascal_names_for(tables: Iterable[CatalogTable]) -> dict[str, str]:
+    r"""Map each table IDENTITY to a COLLISION-FREE PascalCase local name.
 
     :func:`to_pascal` is lossy: it strips every character outside
     ``[a-zA-Z0-9\s_\-]``, treats space/underscore/hyphen as one separator
     class, and normalizes case. So ``order_item``, ``order-item``,
     ``Order_Item``, and ``ORDER ITEM`` all collapse onto ``OrderItem``, and any
     name made entirely of stripped characters collapses onto the ``"Entity"``
-    fallback. Minting class / TriplesMap IRIs straight from ``to_pascal`` therefore
+    fallback. Two tables in different databases can also share a bare name
+    outright. Minting class / TriplesMap IRIs straight from ``to_pascal`` therefore
     silently FUSES distinct source tables onto one IRI: one class carrying both
     tables' labels, key axioms, and cardinality restrictions, and — worse — one
     TriplesMap carrying two ``rr:logicalTable`` / ``rr:tableName`` values, which
@@ -184,12 +202,22 @@ def pascal_names_for(names: Iterable[str]) -> dict[str, str]:
     either rejects the whole mapping (VKG load fails for the namespace) or picks
     one table non-deterministically and drops the other's data.
 
-    This helper resolves collisions instead: the first name (in the caller's
-    order) keeps the bare PascalCase form so existing single-table-per-name
-    deployments mint byte-identical IRIs, and each subsequent colliding name gets
-    ``{Pascal}_{sha256(name)[:8]}`` appended. The discriminator is derived from
-    the verbatim name, so the assignment is deterministic given the same input
-    order and is reproducible across the ontology builder, the R2RML builder, and
+    This helper resolves collisions instead. Within a colliding set, ONE identity
+    keeps the bare PascalCase form so existing single-table-per-name deployments
+    mint byte-identical IRIs, and the others get ``{Pascal}_{sha256(identity)[:8]}``
+    appended.
+
+    Which one keeps the bare form is decided by ``min()`` over the identities, NOT
+    by input order. Order would be the more obvious rule and is wrong here: the
+    caller's list comes from ``_catalog_to_tables``, which flattens catalogs in
+    whatever order Glue / OMD enumerated them and never sorts. Under an
+    order-dependent rule, re-inducing the same schema after an enumeration change
+    moves the bare name to a different table, so the IRIs in a newly generated
+    mapping stop matching the ones in an already-accepted ontology — the exact
+    divergence this helper exists to prevent. Keying on the identity instead makes
+    the assignment a pure function of the schema.
+
+    The result is reproducible across the ontology builder, the R2RML builder, and
     the SHACL config generator — all three must agree or the artifacts diverge.
 
     Callers should also surface a collision to the user (see the ``log.warning``
@@ -198,34 +226,94 @@ def pascal_names_for(names: Iterable[str]) -> dict[str, str]:
     the source.
 
     Args:
-        names: Verbatim table names, in a stable order.
+        tables: Tables in the induction run. Duplicate identities are collapsed.
 
     Returns:
-        ``{verbatim_name: unique_pascal_local_name}`` covering every input name.
+        ``{table_identity: unique_pascal_local_name}`` covering every input table,
+        keyed by :func:`table_identity` — NOT by ``table.name``.
     """
-    result: dict[str, str] = {}
-    taken: set[str] = set()
-    for name in names:
-        if name in result:
+    identities: list[str] = []
+    display_base: dict[str, str] = {}
+    for table in tables:
+        identity = table_identity(table)
+        if identity in display_base:
             continue  # duplicate entry for the same table — one mapping is enough
-        base = to_pascal(name)
-        candidate = base
-        if candidate in taken:
-            candidate = f"{base}_{_name_discriminator(name)}"
+        identities.append(identity)
+        display_base[identity] = to_pascal(table.name)
+
+    by_base: dict[str, list[str]] = {}
+    for identity in identities:
+        by_base.setdefault(display_base[identity], []).append(identity)
+
+    assigned: dict[str, str] = {}
+    taken: set[str] = set()
+    # Sorted so that a residual collision between one base and another base's
+    # discriminated form resolves the same way on every run.
+    for base in sorted(by_base):
+        members = by_base[base]
+        keeper = min(members)
+        for identity in sorted(members):
+            candidate = base if identity == keeper else f"{base}_{_name_discriminator(identity)}"
+            if identity != keeper:
+                log.warning(
+                    "table_name_collides_after_pascal_case",
+                    extra={"table": identity, "collided_on": base, "minted": candidate},
+                )
+            if candidate in taken:
+                # Pathological: the form is already taken (identities were deduped
+                # above, so this needs a genuine hash collision, or a base equal to
+                # another base's discriminated form). Widen until unique.
+                candidate = f"{base}_{_name_discriminator(identity)}"
+                suffix = 2
+                while candidate in taken:
+                    candidate = f"{base}_{_name_discriminator(identity)}_{suffix}"
+                    suffix += 1
+            taken.add(candidate)
+            assigned[identity] = candidate
+    # Returned in caller order: the assignment does not depend on it, but stable
+    # iteration keeps logs and serialized artifacts diff-friendly.
+    return {identity: assigned[identity] for identity in identities}
+
+
+def reference_index(tables: Iterable[CatalogTable]) -> dict[str, str]:
+    """Map the forms an FK target can be written in to a table identity.
+
+    ``referredColumns`` names its target table WITHOUT a database qualifier —
+    :func:`parse_referred_column` yields ``(table, column)`` — so resolving a
+    parent requires a lookup keyed on the bare name. That is ambiguous the moment
+    two databases in the run contain the same table name, which is exactly the case
+    :func:`table_identity` exists for.
+
+    Keys, in the order callers should try them:
+
+    - ``"{sourceSchema}.{name}"`` — prefer the referrer's own database. An FK
+      almost never crosses databases, so this is the reading that matches the SQL
+      the mapping will be compiled into.
+    - ``"{name}"`` — only when that bare name is unambiguous across the whole run.
+      An ambiguous bare name is deliberately ABSENT so the caller falls back to its
+      out-of-run behaviour rather than picking a parent at random; a wrong
+      ``rr:parentTriplesMap`` joins real data to the wrong table, which is worse
+      than an unresolved reference.
+    - the identity itself, so an already-qualified reference resolves too.
+    """
+    index: dict[str, str] = {}
+    by_name: dict[str, list[str]] = {}
+    for table in tables:
+        identity = table_identity(table)
+        index[identity] = identity
+        if table.sourceSchema:
+            index[f"{table.sourceSchema}.{table.name}"] = identity
+        if identity not in by_name.get(table.name, []):
+            by_name.setdefault(table.name, []).append(identity)
+    for name, identities in by_name.items():
+        if len(identities) == 1:
+            index.setdefault(name, identities[0])
+        else:
             log.warning(
-                "table_name_collides_after_pascal_case",
-                extra={"table": name, "collided_on": base, "minted": candidate},
+                "fk_target_table_name_is_ambiguous",
+                extra={"table": name, "candidates": sorted(identities)},
             )
-            # Pathological: the discriminated form is itself taken (two tables
-            # with the same verbatim name would have been deduped above, so this
-            # needs a genuine hash collision). Widen until unique.
-            suffix = 2
-            while candidate in taken:
-                candidate = f"{base}_{_name_discriminator(name)}_{suffix}"
-                suffix += 1
-        taken.add(candidate)
-        result[name] = candidate
-    return result
+    return index
 
 
 def composite_fk_is_usable(tc: CatalogConstraint) -> bool:
@@ -317,9 +405,12 @@ def composite_fk_columns(table: CatalogTable) -> dict[str, str]:
         for col_name in tc.columns:
             if col_name != owner and col_name in table_columns:
                 absorbed.setdefault(col_name, owner)
-    # An anchor is never absorbed: it carries its own relationship. This can only
-    # bite when constraints overlap — `composite_fk_anchors` skips folded columns,
-    # so a column it chose as an anchor was not folded in by an earlier one.
+    # An anchor is never absorbed: it carries its own relationship. This also
+    # overrides the malformed pass above, which may have marked the column as
+    # relationship-free because a DIFFERENT, broken constraint lists it —
+    # ``build_r2rml`` checks the anchor before the malformed degradation for the
+    # same reason, and the two must agree or the ontology declares an
+    # ``owl:ObjectProperty`` against an ``rr:datatype`` literal.
     for anchor in anchors:
         absorbed.pop(anchor, None)
     return absorbed
@@ -471,22 +562,42 @@ class InductionStrategy(ABC):
         g.bind("ind", ns)
         g.bind("xsd", XSD)
 
-        # Build a lookup from table name → TriplesMap URI for parentTriplesMap refs.
-        # Local names come from the collision-resolving helper, not bare
-        # to_pascal: two tables differing only in separators/case would otherwise
-        # share one TriplesMap IRI and produce two rr:tableName values on it
-        # (invalid R2RML — see pascal_names_for).
-        pascal_by_name = pascal_names_for(t.name for t in tables)
+        # Build a lookup from table identity → TriplesMap URI for parentTriplesMap
+        # refs. Local names come from the collision-resolving helper, not bare
+        # to_pascal: two tables differing only in separators/case — or two tables
+        # with the same bare name in different databases — would otherwise share
+        # one TriplesMap IRI and produce two rr:tableName values on it (invalid
+        # R2RML — see pascal_names_for). The key is the IDENTITY, not the name:
+        # keying on the name is what let same-named tables collapse.
+        pascal_by_id = pascal_names_for(tables)
         # Property local names derive from the (possibly discriminated) class
         # local name, so a disambiguated class carries disambiguated predicates.
-        camel_by_name = {n: p[0].lower() + p[1:] if p else p for n, p in pascal_by_name.items()}
-        tmap_by_name: dict[str, URIRef] = {}
+        camel_by_id = {i: p[0].lower() + p[1:] if p else p for i, p in pascal_by_id.items()}
+        # How an FK's bare target name resolves to an identity (schema-qualified
+        # first, then bare when unambiguous).
+        ref_index = reference_index(tables)
+        tmap_by_id: dict[str, URIRef] = {}
         for table in tables:
-            tmap_by_name[table.name] = ns[f"TriplesMap_{pascal_by_name[table.name]}"]
+            identity = table_identity(table)
+            tmap_by_id[identity] = ns[f"TriplesMap_{pascal_by_id[identity]}"]
+
+        def _parent_tmap(target_name: str, referrer: CatalogTable) -> URIRef:
+            """Resolve an FK target table name to its TriplesMap IRI."""
+            qualified = f"{referrer.sourceSchema}.{target_name}" if referrer.sourceSchema else None
+            target_id = (qualified and ref_index.get(qualified)) or ref_index.get(target_name)
+            if target_id is not None and target_id in tmap_by_id:
+                return tmap_by_id[target_id]
+            # Target table is outside this induction run (or its bare name is
+            # ambiguous, in which case guessing a parent would join real data to
+            # the wrong table). Fall back to the bare form — nothing to collide
+            # with here, since a table we did not process has no TriplesMap in
+            # this mapping either.
+            return ns[f"TriplesMap_{to_pascal(target_name)}"]
 
         for table in tables:
-            tmap = tmap_by_name[table.name]
-            table_cls = ns[pascal_by_name[table.name]]
+            identity = table_identity(table)
+            tmap = tmap_by_id[identity]
+            table_cls = ns[pascal_by_id[identity]]
 
             g.add((tmap, RDF.type, RR.TriplesMap))
             _annotate_triples_map(g, tmap, table)
@@ -551,7 +662,7 @@ class InductionStrategy(ABC):
                 if col.name in absorbed_columns:
                     pom = URIRef(f"{tmap}/POM_{to_pascal(col.name)}")
                     g.add((tmap, RR.predicateObjectMap, pom))
-                    g.add((pom, RR.predicate, ns[f"{camel_by_name[table.name]}_{to_camel(col.name)}"]))
+                    g.add((pom, RR.predicate, ns[f"{camel_by_id[identity]}_{to_camel(col.name)}"]))
                     om = URIRef(f"{pom}/ObjectMap")
                     g.add((pom, RR.objectMap, om))
                     g.add((om, RR.column, Literal(sql_ident(col.name))))
@@ -561,7 +672,7 @@ class InductionStrategy(ABC):
                 pom = URIRef(f"{tmap}/POM_{to_pascal(col.name)}")
                 g.add((tmap, RR.predicateObjectMap, pom))
 
-                prop_uri = ns[f"{camel_by_name[table.name]}_{to_camel(col.name)}"]
+                prop_uri = ns[f"{camel_by_id[identity]}_{to_camel(col.name)}"]
                 g.add((pom, RR.predicate, prop_uri))
 
                 om = URIRef(f"{pom}/ObjectMap")
@@ -570,6 +681,34 @@ class InductionStrategy(ABC):
                 # This column anchors a composite FK when the shared anchor table
                 # says so — never by re-deriving it here.
                 composite_fk = composite_anchors.get(col.name)
+
+                if composite_fk is not None and composite_fk.referredColumns:
+                    # Composite FK: emit a single Referencing Object Map for the
+                    # entire relationship, with one joinCondition per column pair.
+                    #
+                    # Checked BEFORE the malformed branch below, and the order is
+                    # load-bearing. A column can sit in a malformed constraint AND
+                    # anchor a well-formed one; degrading it to a literal because
+                    # some OTHER constraint mentioning it is broken threw away a
+                    # relationship that is perfectly expressible, and left the
+                    # ontology (which asks composite_fk_anchors, and so still
+                    # declared an owl:ObjectProperty with rdfs:range) contradicting
+                    # this mapping's rr:datatype — the very mismatch the composite-FK
+                    # fix set out to remove.
+                    fk_target, _ = parse_referred_column(composite_fk.referredColumns[0])
+                    g.add((om, RR.parentTriplesMap, _parent_tmap(fk_target, table)))
+                    for child_col, ref_col in zip(composite_fk.columns, composite_fk.referredColumns, strict=True):
+                        _, parsed_parent = parse_referred_column(ref_col)
+                        parent_col = parsed_parent if parsed_parent is not None else ref_col
+                        jc = BNode()
+                        g.add((om, RR.joinCondition, jc))
+                        g.add((jc, RR.child, Literal(sql_ident(child_col))))
+                        g.add((jc, RR.parent, Literal(sql_ident(parent_col))))
+
+                    # No bookkeeping needed: composite_fk_anchors already assigned
+                    # each constraint to exactly one column, so no other column can
+                    # re-emit this relationship.
+                    continue
 
                 if col.name in malformed_composite_columns:
                     # columns/referredColumns disagree in length, or the targets span
@@ -584,32 +723,6 @@ class InductionStrategy(ABC):
                     )
                     g.add((om, RR.column, Literal(sql_ident(col.name))))
                     g.add((om, RR.datatype, xsd_for_column(col.dataType, col.name)))
-                    continue
-
-                if composite_fk is not None and composite_fk.referredColumns:
-                    # Composite FK: emit a single Referencing Object Map for the
-                    # entire relationship, with one joinCondition per column pair.
-                    fk_target, _ = parse_referred_column(composite_fk.referredColumns[0])
-                    parent_tmap = tmap_by_name.get(fk_target)
-                    if parent_tmap is None:
-                        # Target table is outside this induction run, so it has no
-                        # entry in pascal_by_name. Fall back to the bare form —
-                        # nothing to collide with here, since a table we did not
-                        # process has no TriplesMap in this mapping either.
-                        parent_tmap = ns[f"TriplesMap_{to_pascal(fk_target)}"]
-
-                    g.add((om, RR.parentTriplesMap, parent_tmap))
-                    for child_col, ref_col in zip(composite_fk.columns, composite_fk.referredColumns, strict=True):
-                        _, parsed_parent = parse_referred_column(ref_col)
-                        parent_col = parsed_parent if parsed_parent is not None else ref_col
-                        jc = BNode()
-                        g.add((om, RR.joinCondition, jc))
-                        g.add((jc, RR.child, Literal(sql_ident(child_col))))
-                        g.add((jc, RR.parent, Literal(sql_ident(parent_col))))
-
-                    # No bookkeeping needed: composite_fk_anchors already assigned
-                    # each constraint to exactly one column, so no other column can
-                    # re-emit this relationship.
                     continue
 
                 # Check for simple (single-column) FK
@@ -633,9 +746,7 @@ class InductionStrategy(ABC):
                     # fk_parent_col is required — without it we cannot emit a valid
                     # joinCondition and a bare parentTriplesMap would produce a
                     # Cartesian product in Ontop (R2RML §7.5).
-                    parent_tmap = tmap_by_name.get(simple_fk_target)
-                    if parent_tmap is None:
-                        parent_tmap = ns[f"TriplesMap_{to_pascal(simple_fk_target)}"]
+                    parent_tmap = _parent_tmap(simple_fk_target, table)
 
                     g.add((om, RR.parentTriplesMap, parent_tmap))
                     jc = BNode()

--- a/packages/ontology-engine/src/coa_ontology/inducer/strategies/base.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/strategies/base.py
@@ -17,7 +17,7 @@ from coa_common.constants import VOCAB_URI
 from rdflib import RDF, XSD, BNode, Graph, Literal, Namespace, URIRef
 
 from coa_ontology.inducer.schemas import ConceptMatch
-from coa_ontology.inducer.services.data_catalog import CatalogTable
+from coa_ontology.inducer.services.data_catalog import CatalogTable, parse_referred_column
 
 log = logging.getLogger(__name__)
 
@@ -240,7 +240,7 @@ def composite_fk_is_usable(tc) -> bool:
         return False
     if len(tc.columns) != len(tc.referredColumns):
         return False
-    fk_tables = {rc.split(".")[0] for rc in tc.referredColumns if "." in rc}
+    fk_tables = {parse_referred_column(rc)[0] for rc in tc.referredColumns if "." in rc}
     return len(fk_tables) <= 1
 
 
@@ -515,7 +515,7 @@ class InductionStrategy(ABC):
                         continue
 
                     # Validate: all referredColumns must reference the same target table.
-                    fk_tables = {rc.split(".")[0] for rc in composite_fk.referredColumns if "." in rc}
+                    fk_tables = {parse_referred_column(rc)[0] for rc in composite_fk.referredColumns if "." in rc}
                     if len(fk_tables) > 1:
                         log.warning(
                             "Skipping composite FK on %s: referredColumns span multiple tables %s",
@@ -528,7 +528,7 @@ class InductionStrategy(ABC):
                         g.add((om, RR.datatype, dt))
                         continue
 
-                    fk_target = composite_fk.referredColumns[0].split(".")[0]
+                    fk_target, _ = parse_referred_column(composite_fk.referredColumns[0])
                     parent_tmap = tmap_by_name.get(fk_target)
                     if parent_tmap is None:
                         # Target table is outside this induction run, so it has no
@@ -539,8 +539,8 @@ class InductionStrategy(ABC):
 
                     g.add((om, RR.parentTriplesMap, parent_tmap))
                     for child_col, ref_col in zip(composite_fk.columns, composite_fk.referredColumns, strict=True):
-                        parts = ref_col.split(".")
-                        parent_col = parts[-1] if len(parts) >= 2 else parts[0]
+                        _, parsed_parent = parse_referred_column(ref_col)
+                        parent_col = parsed_parent if parsed_parent is not None else ref_col
                         jc = BNode()
                         g.add((om, RR.joinCondition, jc))
                         g.add((jc, RR.child, Literal(sql_ident(child_col))))
@@ -563,9 +563,7 @@ class InductionStrategy(ABC):
                             and tc.referredColumns
                         ):
                             is_fk = True
-                            parts = tc.referredColumns[0].split(".")
-                            simple_fk_target = parts[0]
-                            fk_parent_col = parts[-1] if len(parts) >= 2 else None
+                            simple_fk_target, fk_parent_col = parse_referred_column(tc.referredColumns[0])
                             break
 
                 if is_fk and simple_fk_target and fk_parent_col:

--- a/packages/ontology-engine/src/coa_ontology/inducer/strategies/base.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/strategies/base.py
@@ -17,7 +17,11 @@ from coa_common.constants import VOCAB_URI
 from rdflib import RDF, XSD, BNode, Graph, Literal, Namespace, URIRef
 
 from coa_ontology.inducer.schemas import ConceptMatch
-from coa_ontology.inducer.services.data_catalog import CatalogTable, parse_referred_column
+from coa_ontology.inducer.services.data_catalog import (
+    CatalogConstraint,
+    CatalogTable,
+    parse_referred_column,
+)
 
 log = logging.getLogger(__name__)
 
@@ -224,7 +228,7 @@ def pascal_names_for(names: Iterable[str]) -> dict[str, str]:
     return result
 
 
-def composite_fk_is_usable(tc) -> bool:
+def composite_fk_is_usable(tc: CatalogConstraint) -> bool:
     """True when a composite FK constraint can produce a valid Referencing Object Map.
 
     :meth:`InductionStrategy.build_r2rml` degrades a composite FK to plain datatype
@@ -273,30 +277,96 @@ def composite_fk_columns(table: CatalogTable) -> dict[str, str]:
         ``{column: ""}`` for every column of a malformed composite FK. The owning
         (first) column of a USABLE composite FK is absent — it keeps both its POM
         and its object property. Empty when the table has no composite FK.
+
+    Mirrors :meth:`InductionStrategy.build_r2rml`'s CONSUMING walk exactly, which
+    matters when two composite FKs share a column. For ``FK1 = (a, b) -> p1`` and
+    ``FK2 = (b, c) -> p2``, walking the columns in order assigns ``a`` to FK1
+    (absorbing ``b``), and then ``c`` — reached with FK1 already consumed — anchors
+    FK2. A non-consuming implementation instead matched ``c`` against FK2 while
+    treating it as absorbed by ``b``, which silently dropped the child→p2
+    relationship from BOTH artifacts. So the walk order and the removal are
+    load-bearing, not incidental.
     """
     absorbed: dict[str, str] = {}
     if not table.tableConstraints:
         return absorbed
     table_columns = {c.name for c in table.columns}
+
+    # Malformed composite FKs first: build_r2rml degrades every one of their
+    # columns to a literal regardless of position, so they never anchor anything.
+    remaining = []
     for tc in table.tableConstraints:
         if tc.constraintType != "FOREIGN_KEY" or not tc.referredColumns or len(tc.columns or []) <= 1:
             continue
-        if not composite_fk_is_usable(tc):
-            # Degraded to datatype ObjectMaps in the mapping — no object property
-            # for ANY of these columns, the first one included.
+        if composite_fk_is_usable(tc):
+            remaining.append(tc)
+        else:
             for col_name in tc.columns:
                 if col_name in table_columns:
                     absorbed.setdefault(col_name, "")
-            continue
-        # build_r2rml anchors the POM on the first column of the constraint that
-        # the table actually has (it iterates table.columns), so mirror that.
-        owner = next((c for c in table.columns if c.name in tc.columns), None)
-        if owner is None:
-            continue
+
+    # Then replay build_r2rml's walk: for each column in order, claim the first
+    # not-yet-claimed constraint it participates in. That column becomes the
+    # anchor, and the constraint is consumed so a later column cannot claim it
+    # again. Anchors are recorded as they are decided; absorbed columns are
+    # resolved afterwards, because a column can be a LATER constraint's anchor
+    # even though an earlier constraint also lists it — with (a,b)->p1,
+    # (b,c)->p2, (c,d)->p3, `c` anchors FK2 and must not be absorbed by FK3.
+    anchors = composite_fk_anchors(table)
+    for owner, tc in anchors.items():
         for col_name in tc.columns:
-            if col_name != owner.name and col_name in table_columns:
-                absorbed.setdefault(col_name, owner.name)
+            if col_name != owner and col_name in table_columns:
+                absorbed.setdefault(col_name, owner)
+    # An anchor is never absorbed: it carries its own relationship. This can only
+    # bite when constraints overlap — `composite_fk_anchors` skips folded columns,
+    # so a column it chose as an anchor was not folded in by an earlier one.
+    for anchor in anchors:
+        absorbed.pop(anchor, None)
     return absorbed
+
+
+def composite_fk_anchors(table: CatalogTable) -> dict[str, CatalogConstraint]:
+    """Map each column that ANCHORS a usable composite FK to that constraint.
+
+    Single source of truth for the anchor assignment, consumed by both
+    :meth:`InductionStrategy.build_r2rml` (which emits one Referencing Object Map
+    per anchor) and :func:`composite_fk_columns` (which derives the absorbed
+    columns from it). Splitting the two apart is what let them disagree: the
+    mapping walked and CONSUMED constraints column by column while the ontology
+    side computed absorption independently, so for two FKs sharing a column they
+    picked different anchors and the relationship landed on different properties
+    in each artifact.
+
+    The rule reproduces the mapping's original walk exactly: visit columns in table
+    order; SKIP a column already folded into an earlier anchor's map; otherwise let
+    it claim the first unclaimed constraint it participates in, and consume that
+    constraint. Both the skip and the consumption matter. For (a,b)->p1 and
+    (b,c)->p2: `a` claims p1 and folds in `b`; `b` is skipped BECAUSE it is folded
+    in, so p2 falls to `c`. Dropping the skip hands p2 to `b` instead, which moves
+    the relationship onto a different property than the original mapping used.
+    """
+    anchors: dict[str, CatalogConstraint] = {}
+    if not table.tableConstraints:
+        return anchors
+    remaining = [
+        tc
+        for tc in table.tableConstraints
+        if tc.constraintType == "FOREIGN_KEY"
+        and tc.referredColumns
+        and len(tc.columns or []) > 1
+        and composite_fk_is_usable(tc)
+    ]
+    folded: set[str] = set()
+    for col in table.columns:
+        if col.name in folded:
+            continue
+        claimed = next((tc for tc in remaining if col.name in tc.columns), None)
+        if claimed is None:
+            continue
+        anchors[col.name] = claimed
+        remaining.remove(claimed)
+        folded.update(c for c in claimed.columns if c != col.name)
+    return anchors
 
 
 def _annotate_triples_map(g: Graph, tmap: URIRef, table: CatalogTable) -> None:
@@ -446,19 +516,27 @@ class InductionStrategy(ABC):
             g.add((subj, RR.template, Literal(template)))
             g.add((subj, RR["class"], table_cls))
 
-            # Pre-collect composite FK constraints so we can detect when a column
-            # participates in a multi-column FK (needs special handling).
-            composite_fk_constraints = []
-            if table.tableConstraints:
-                for tc in table.tableConstraints:
-                    if tc.constraintType == "FOREIGN_KEY" and tc.referredColumns and len(tc.columns) > 1:
-                        composite_fk_constraints.append(tc)
-
-            # Columns a USABLE composite FK folds into its owning column's
-            # referencing map. Computed up front (not accumulated while iterating)
-            # so the branch below is independent of column order, and shared with
-            # the ontology builder so both agree on which columns are literals.
+            # Which column carries which composite FK, and which columns it folds
+            # in. Both come from the SAME helpers the ontology builder uses, so the
+            # two artifacts cannot disagree about where a relationship lives — they
+            # previously derived it independently (a consuming walk here, a separate
+            # computation there) and picked different anchors for FKs sharing a
+            # column.
+            composite_anchors = composite_fk_anchors(table)
             absorbed_columns = {name for name, owner in composite_fk_columns(table).items() if owner}
+
+            # Malformed composite FKs never anchor anything (see
+            # composite_fk_is_usable); their columns fall through to the datatype
+            # path below, which is what build_r2rml has always done.
+            malformed_composite_columns = {
+                col_name
+                for tc in (table.tableConstraints or [])
+                if tc.constraintType == "FOREIGN_KEY"
+                and tc.referredColumns
+                and len(tc.columns or []) > 1
+                and not composite_fk_is_usable(tc)
+                for col_name in tc.columns
+            }
 
             for col in table.columns:
                 # A column absorbed into a sibling's composite-FK Referencing
@@ -489,45 +567,28 @@ class InductionStrategy(ABC):
                 om = URIRef(f"{pom}/ObjectMap")
                 g.add((pom, RR.objectMap, om))
 
-                # Check if this column is part of a composite FK
-                composite_fk = None
-                for tc in composite_fk_constraints:
-                    if col.name in tc.columns:
-                        composite_fk = tc
-                        break
+                # This column anchors a composite FK when the shared anchor table
+                # says so — never by re-deriving it here.
+                composite_fk = composite_anchors.get(col.name)
+
+                if col.name in malformed_composite_columns:
+                    # columns/referredColumns disagree in length, or the targets span
+                    # several tables: no join can be derived, so the column degrades
+                    # to a literal. composite_fk_columns reports these as
+                    # non-object-properties, keeping the ontology in step.
+                    log.warning(
+                        "Composite FK on %s is malformed (column/target counts differ, or targets span "
+                        "several tables); mapping %s as a literal",
+                        table.name,
+                        col.name,
+                    )
+                    g.add((om, RR.column, Literal(sql_ident(col.name))))
+                    g.add((om, RR.datatype, xsd_for_column(col.dataType, col.name)))
+                    continue
 
                 if composite_fk is not None and composite_fk.referredColumns:
                     # Composite FK: emit a single Referencing Object Map for the
                     # entire relationship, with one joinCondition per column pair.
-
-                    # Validate: columns and referredColumns must have equal length.
-                    if len(composite_fk.columns) != len(composite_fk.referredColumns):
-                        log.warning(
-                            "Skipping malformed composite FK on %s: columns/referredColumns length mismatch (%d vs %d)",
-                            table.name,
-                            len(composite_fk.columns),
-                            len(composite_fk.referredColumns),
-                        )
-                        composite_fk_constraints.remove(composite_fk)
-                        g.add((om, RR.column, Literal(sql_ident(col.name))))
-                        dt = xsd_for(col.dataType)
-                        g.add((om, RR.datatype, dt))
-                        continue
-
-                    # Validate: all referredColumns must reference the same target table.
-                    fk_tables = {parse_referred_column(rc)[0] for rc in composite_fk.referredColumns if "." in rc}
-                    if len(fk_tables) > 1:
-                        log.warning(
-                            "Skipping composite FK on %s: referredColumns span multiple tables %s",
-                            table.name,
-                            fk_tables,
-                        )
-                        composite_fk_constraints.remove(composite_fk)
-                        g.add((om, RR.column, Literal(sql_ident(col.name))))
-                        dt = xsd_for(col.dataType)
-                        g.add((om, RR.datatype, dt))
-                        continue
-
                     fk_target, _ = parse_referred_column(composite_fk.referredColumns[0])
                     parent_tmap = tmap_by_name.get(fk_target)
                     if parent_tmap is None:
@@ -546,8 +607,9 @@ class InductionStrategy(ABC):
                         g.add((jc, RR.child, Literal(sql_ident(child_col))))
                         g.add((jc, RR.parent, Literal(sql_ident(parent_col))))
 
-                    # Remove from composite list to avoid re-processing
-                    composite_fk_constraints.remove(composite_fk)
+                    # No bookkeeping needed: composite_fk_anchors already assigned
+                    # each constraint to exactly one column, so no other column can
+                    # re-emit this relationship.
                     continue
 
                 # Check for simple (single-column) FK

--- a/packages/ontology-engine/src/coa_ontology/inducer/strategies/rigor_ontology.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/strategies/rigor_ontology.py
@@ -29,7 +29,7 @@ from rdflib import OWL, RDF, RDFS, XSD, BNode, Graph, Literal, Namespace, URIRef
 from rdflib.namespace import SKOS
 
 from coa_ontology.inducer.schemas import ConceptMatch
-from coa_ontology.inducer.services.data_catalog import CatalogTable
+from coa_ontology.inducer.services.data_catalog import CatalogTable, parse_referred_column
 from coa_ontology.inducer.strategies.base import InductionStrategy
 
 log = logging.getLogger(__name__)
@@ -393,8 +393,7 @@ class RigorOntologyStrategy(InductionStrategy):
             if table and table.tableConstraints:
                 for tc in table.tableConstraints:
                     if tc.constraintType == "FOREIGN_KEY" and tc.referredColumns:
-                        # referredColumns entries look like "TableName.column"
-                        ref_table = tc.referredColumns[0].split(".")[0]
+                        ref_table, _ = parse_referred_column(tc.referredColumns[0])
                         if ref_table in table_map and ref_table != name:
                             visit(ref_table)
             in_progress.discard(name)
@@ -1010,8 +1009,5 @@ class RigorOntologyStrategy(InductionStrategy):
             return None, None
         for tc in table.tableConstraints:
             if tc.constraintType == "FOREIGN_KEY" and col_name in tc.columns and tc.referredColumns:
-                parts = tc.referredColumns[0].split(".")
-                target_table = parts[-2] if len(parts) >= 2 else parts[0]
-                target_pk = parts[-1]
-                return target_table, target_pk
+                return parse_referred_column(tc.referredColumns[0])
         return None, None

--- a/packages/ontology-engine/src/coa_ontology/inducer/strategies/table_to_ontology.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/strategies/table_to_ontology.py
@@ -24,7 +24,12 @@ from rdflib.namespace import SKOS
 from coa_ontology.inducer.schemas import ConceptMatch
 from coa_ontology.inducer.services.data_catalog import CatalogTable
 from coa_ontology.inducer.services.subtype_detection import detect_pk_sharing_subtypes
-from coa_ontology.inducer.strategies.base import SCL, InductionStrategy, pascal_names_for
+from coa_ontology.inducer.strategies.base import (
+    SCL,
+    InductionStrategy,
+    composite_fk_columns,
+    pascal_names_for,
+)
 
 log = logging.getLogger(__name__)
 
@@ -333,13 +338,23 @@ class TableToOntologyStrategy(InductionStrategy):
                         g.add((table_cls, OWL.hasKey, key_bnode))
                         break
 
+            # Columns absorbed into a sibling's composite-FK POM. build_r2rml emits
+            # ONE Referencing Object Map per composite FK (R2RML §7.5), anchored on
+            # the constraint's first column, so declaring an ObjectProperty for the
+            # others would mint properties with no mapping behind them — present in
+            # the TBox and in the NL→SPARQL context, but unresolvable by Ontop, so
+            # queries using them silently return nothing. Declare them as plain
+            # datatype properties instead: the columns do exist, they simply are not
+            # the relationship's anchor.
+            absorbed_fk_columns = composite_fk_columns(table)
+
             for col in table.columns:
                 prop_uri = table_prop(table.name, col.name)
                 is_fk = False
                 fk_target = None
                 fk_target_col = None
                 fk_provenance: str | None = None
-                if table.tableConstraints:
+                if table.tableConstraints and col.name not in absorbed_fk_columns:
                     for tc in table.tableConstraints:
                         if tc.constraintType == "FOREIGN_KEY" and col.name in tc.columns and tc.referredColumns:
                             is_fk = True
@@ -378,6 +393,21 @@ class TableToOntologyStrategy(InductionStrategy):
                     g.add((prop_uri, RDF.type, OWL.DatatypeProperty))
                     g.add((prop_uri, RDFS.domain, table_cls))
                     g.add((prop_uri, RDFS.range, _xsd_for(col.dataType, col.name)))
+                    if col.name in absorbed_fk_columns:
+                        # Record why an FK column is a datatype property, so the
+                        # relationship stays discoverable from the ontology alone.
+                        owner = absorbed_fk_columns[col.name]
+                        note = (
+                            f"Part of a composite foreign key on {table.name}; the relationship is carried by "
+                            f"{camel_by_name[table.name]}_{_to_camel(owner)}"
+                            if owner
+                            else (
+                                f"Part of a malformed composite foreign key on {table.name} "
+                                "(column/target counts differ, or targets span several tables); "
+                                "mapped as a literal because no join can be derived"
+                            )
+                        )
+                        g.add((prop_uri, RDFS.comment, Literal(note)))
 
                 g.add((prop_uri, RDFS.label, Literal(col.name)))
                 if col.description and not (is_fk and fk_target):

--- a/packages/ontology-engine/src/coa_ontology/inducer/strategies/table_to_ontology.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/strategies/table_to_ontology.py
@@ -27,8 +27,11 @@ from coa_ontology.inducer.services.subtype_detection import detect_pk_sharing_su
 from coa_ontology.inducer.strategies.base import (
     SCL,
     InductionStrategy,
+    composite_fk_anchors,
     composite_fk_columns,
     pascal_names_for,
+    reference_index,
+    table_identity,
 )
 
 log = logging.getLogger(__name__)
@@ -278,17 +281,30 @@ class TableToOntologyStrategy(InductionStrategy):
         # Collision-free class local names, shared with build_r2rml (base.py) and
         # the SHACL config generator so all three artifacts name the same class
         # identically. Bare _to_pascal would fuse tables differing only in
-        # separators/case (order_item vs order-item) onto one class IRI.
-        pascal_by_name = pascal_names_for(t.name for t in tables)
+        # separators/case (order_item vs order-item), or two same-named tables from
+        # different databases, onto one class IRI. Keyed by table IDENTITY.
+        pascal_by_id = pascal_names_for(tables)
         # Property local names are derived from the class local name (not from
         # _to_camel(table.name)) so a discriminated class carries discriminated
         # property IRIs too — otherwise the two fused tables' properties would
         # still collide even though their classes no longer do.
-        camel_by_name = {n: p[0].lower() + p[1:] if p else p for n, p in pascal_by_name.items()}
+        camel_by_id = {i: p[0].lower() + p[1:] if p else p for i, p in pascal_by_id.items()}
+        ref_index = reference_index(tables)
 
-        def table_prop(table_name: str, column_name: str) -> URIRef:
-            """Mint the property IRI for ``table_name.column_name``."""
-            return ns[f"{camel_by_name.get(table_name, _to_camel(table_name))}_{_to_camel(column_name)}"]
+        def table_prop(table: CatalogTable, column_name: str) -> URIRef:
+            """Mint the property IRI for ``table.column_name``."""
+            local = camel_by_id.get(table_identity(table), _to_camel(table.name))
+            return ns[f"{local}_{_to_camel(column_name)}"]
+
+        def parent_class(target_name: str, referrer: CatalogTable) -> URIRef:
+            """Resolve an FK target table name to its class IRI."""
+            qualified = f"{referrer.sourceSchema}.{target_name}" if referrer.sourceSchema else None
+            target_id = (qualified and ref_index.get(qualified)) or ref_index.get(target_name)
+            if target_id is not None and target_id in pascal_by_id:
+                return ns[pascal_by_id[target_id]]
+            # Outside this run, or an ambiguous bare name: fall back to the bare
+            # form, matching build_r2rml's parentTriplesMap fallback.
+            return ns[_to_pascal(target_name)]
 
         for table in tables:
             tm = match_map.get((table.name, ""))
@@ -297,7 +313,7 @@ class TableToOntologyStrategy(InductionStrategy):
             if not is_grounded:
                 novel_tables.add(table.name)
 
-            table_cls = ns[pascal_by_name[table.name]]
+            table_cls = ns[pascal_by_id[table_identity(table)]]
             g.add((table_cls, RDF.type, OWL.Class))
             g.add((table_cls, RDFS.label, Literal(table.name)))
             if table.description:
@@ -332,7 +348,7 @@ class TableToOntologyStrategy(InductionStrategy):
                     if tc.constraintType == "PRIMARY_KEY" and tc.columns:
                         from rdflib.collection import Collection
 
-                        key_props: list = [table_prop(table.name, c) for c in tc.columns]
+                        key_props: list = [table_prop(table, c) for c in tc.columns]
                         key_bnode = BNode()
                         Collection(g, key_bnode, key_props)
                         g.add((table_cls, OWL.hasKey, key_bnode))
@@ -347,25 +363,38 @@ class TableToOntologyStrategy(InductionStrategy):
             # datatype properties instead: the columns do exist, they simply are not
             # the relationship's anchor.
             absorbed_fk_columns = composite_fk_columns(table)
+            # Which column anchors which composite FK — the SAME helper build_r2rml
+            # consults. Resolving the target by "first FOREIGN_KEY constraint that
+            # lists this column" instead let the two artifacts disagree whenever a
+            # column belongs to more than one constraint: the ontology took whichever
+            # came first in ``tableConstraints`` while the mapping used the anchor, so
+            # ``rdfs:range`` and ``rr:parentTriplesMap`` named different parents.
+            composite_anchors = composite_fk_anchors(table)
 
             for col in table.columns:
-                prop_uri = table_prop(table.name, col.name)
+                prop_uri = table_prop(table, col.name)
                 is_fk = False
                 fk_target = None
                 fk_target_col = None
                 fk_provenance: str | None = None
                 if table.tableConstraints and col.name not in absorbed_fk_columns:
-                    for tc in table.tableConstraints:
-                        if tc.constraintType == "FOREIGN_KEY" and col.name in tc.columns and tc.referredColumns:
-                            is_fk = True
-                            fk_target, fk_target_col = parse_referred_column(tc.referredColumns[0])
-                            fk_provenance = tc.relationshipType
-                            break
+                    anchored = composite_anchors.get(col.name)
+                    if anchored is not None and anchored.referredColumns:
+                        is_fk = True
+                        fk_target, fk_target_col = parse_referred_column(anchored.referredColumns[0])
+                        fk_provenance = anchored.relationshipType
+                    else:
+                        for tc in table.tableConstraints:
+                            if tc.constraintType == "FOREIGN_KEY" and col.name in tc.columns and tc.referredColumns:
+                                is_fk = True
+                                fk_target, fk_target_col = parse_referred_column(tc.referredColumns[0])
+                                fk_provenance = tc.relationshipType
+                                break
 
                 if is_fk and fk_target:
                     # In-run tables use the shared (collision-resolved) name;
                     # a target outside this run falls back to the bare form.
-                    parent_cls = ns[pascal_by_name.get(fk_target, _to_pascal(fk_target))]
+                    parent_cls = parent_class(fk_target, table)
                     if (table.name, fk_target) in pk_sharing_confirmed:
                         g.add((table_cls, RDFS.subClassOf, parent_cls))
                         g.add((table_cls, SCL.subClassProvenance, Literal("PK_SHARING")))
@@ -397,7 +426,7 @@ class TableToOntologyStrategy(InductionStrategy):
                         owner = absorbed_fk_columns[col.name]
                         note = (
                             f"Part of a composite foreign key on {table.name}; the relationship is carried by "
-                            f"{camel_by_name[table.name]}_{_to_camel(owner)}"
+                            f"{camel_by_id[table_identity(table)]}_{_to_camel(owner)}"
                             if owner
                             else (
                                 f"Part of a malformed composite foreign key on {table.name} "

--- a/packages/ontology-engine/src/coa_ontology/inducer/strategies/table_to_ontology.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/strategies/table_to_ontology.py
@@ -22,7 +22,7 @@ from rdflib import OWL, RDF, RDFS, XSD, BNode, Graph, Literal, Namespace, URIRef
 from rdflib.namespace import SKOS
 
 from coa_ontology.inducer.schemas import ConceptMatch
-from coa_ontology.inducer.services.data_catalog import CatalogTable
+from coa_ontology.inducer.services.data_catalog import CatalogTable, parse_referred_column
 from coa_ontology.inducer.services.subtype_detection import detect_pk_sharing_subtypes
 from coa_ontology.inducer.strategies.base import (
     SCL,
@@ -358,9 +358,7 @@ class TableToOntologyStrategy(InductionStrategy):
                     for tc in table.tableConstraints:
                         if tc.constraintType == "FOREIGN_KEY" and col.name in tc.columns and tc.referredColumns:
                             is_fk = True
-                            parts = tc.referredColumns[0].split(".")
-                            fk_target = parts[-2] if len(parts) >= 2 else parts[0]
-                            fk_target_col = parts[-1] if len(parts) >= 2 else None
+                            fk_target, fk_target_col = parse_referred_column(tc.referredColumns[0])
                             fk_provenance = tc.relationshipType
                             break
 

--- a/packages/ontology-engine/src/coa_ontology/inducer/strategies/table_to_ontology.py
+++ b/packages/ontology-engine/src/coa_ontology/inducer/strategies/table_to_ontology.py
@@ -24,7 +24,7 @@ from rdflib.namespace import SKOS
 from coa_ontology.inducer.schemas import ConceptMatch
 from coa_ontology.inducer.services.data_catalog import CatalogTable
 from coa_ontology.inducer.services.subtype_detection import detect_pk_sharing_subtypes
-from coa_ontology.inducer.strategies.base import SCL, InductionStrategy
+from coa_ontology.inducer.strategies.base import SCL, InductionStrategy, pascal_names_for
 
 log = logging.getLogger(__name__)
 
@@ -270,6 +270,21 @@ class TableToOntologyStrategy(InductionStrategy):
         pk_sharing_confirmed, pk_sharing_suggested = detect_pk_sharing_subtypes(tables)
         novel_tables = set()
 
+        # Collision-free class local names, shared with build_r2rml (base.py) and
+        # the SHACL config generator so all three artifacts name the same class
+        # identically. Bare _to_pascal would fuse tables differing only in
+        # separators/case (order_item vs order-item) onto one class IRI.
+        pascal_by_name = pascal_names_for(t.name for t in tables)
+        # Property local names are derived from the class local name (not from
+        # _to_camel(table.name)) so a discriminated class carries discriminated
+        # property IRIs too — otherwise the two fused tables' properties would
+        # still collide even though their classes no longer do.
+        camel_by_name = {n: p[0].lower() + p[1:] if p else p for n, p in pascal_by_name.items()}
+
+        def table_prop(table_name: str, column_name: str) -> URIRef:
+            """Mint the property IRI for ``table_name.column_name``."""
+            return ns[f"{camel_by_name.get(table_name, _to_camel(table_name))}_{_to_camel(column_name)}"]
+
         for table in tables:
             tm = match_map.get((table.name, ""))
             is_grounded = tm and tm.match_type in ("exact", "high_confidence")
@@ -277,7 +292,7 @@ class TableToOntologyStrategy(InductionStrategy):
             if not is_grounded:
                 novel_tables.add(table.name)
 
-            table_cls = ns[_to_pascal(table.name)]
+            table_cls = ns[pascal_by_name[table.name]]
             g.add((table_cls, RDF.type, OWL.Class))
             g.add((table_cls, RDFS.label, Literal(table.name)))
             if table.description:
@@ -312,14 +327,14 @@ class TableToOntologyStrategy(InductionStrategy):
                     if tc.constraintType == "PRIMARY_KEY" and tc.columns:
                         from rdflib.collection import Collection
 
-                        key_props: list = [ns[f"{_to_camel(table.name)}_{_to_camel(c)}"] for c in tc.columns]
+                        key_props: list = [table_prop(table.name, c) for c in tc.columns]
                         key_bnode = BNode()
                         Collection(g, key_bnode, key_props)
                         g.add((table_cls, OWL.hasKey, key_bnode))
                         break
 
             for col in table.columns:
-                prop_uri = ns[f"{_to_camel(table.name)}_{_to_camel(col.name)}"]
+                prop_uri = table_prop(table.name, col.name)
                 is_fk = False
                 fk_target = None
                 fk_target_col = None
@@ -335,7 +350,9 @@ class TableToOntologyStrategy(InductionStrategy):
                             break
 
                 if is_fk and fk_target:
-                    parent_cls = ns[_to_pascal(fk_target)]
+                    # In-run tables use the shared (collision-resolved) name;
+                    # a target outside this run falls back to the bare form.
+                    parent_cls = ns[pascal_by_name.get(fk_target, _to_pascal(fk_target))]
                     if (table.name, fk_target) in pk_sharing_confirmed:
                         g.add((table_cls, RDFS.subClassOf, parent_cls))
                         g.add((table_cls, SCL.subClassProvenance, Literal("PK_SHARING")))

--- a/packages/ontology-engine/src/coa_ontology/validation/shapes/config.py
+++ b/packages/ontology-engine/src/coa_ontology/validation/shapes/config.py
@@ -20,6 +20,8 @@ from rdflib.namespace import RDF
 # (they lived in 3+ places). ``base.py`` owns the authoritative copies.
 from coa_ontology.inducer.services.data_catalog import parse_referred_column
 from coa_ontology.inducer.strategies.base import pascal_names_for as _pascal_names_for
+from coa_ontology.inducer.strategies.base import reference_index as _reference_index
+from coa_ontology.inducer.strategies.base import table_identity as _table_identity
 from coa_ontology.inducer.strategies.base import to_camel as _to_camel
 from coa_ontology.inducer.strategies.base import to_pascal as _to_pascal
 from coa_ontology.inducer.strategies.base import xsd_for as _xsd_for
@@ -100,11 +102,13 @@ def generate_config_from_db(tables, uri_prefix: str) -> ConstraintConfig:
 
     # Same collision-resolved local names the ontology and R2RML builders mint,
     # so the shapes target the classes/properties that actually exist.
-    pascal_by_name = _pascal_names_for(t.name for t in tables)
-    camel_by_name = {n: p[0].lower() + p[1:] if p else p for n, p in pascal_by_name.items()}
+    pascal_by_id = _pascal_names_for(tables)
+    camel_by_id = {i: p[0].lower() + p[1:] if p else p for i, p in pascal_by_id.items()}
+    ref_index = _reference_index(tables)
 
     for table in tables:
-        class_uri = f"{ns_str}{pascal_by_name[table.name]}"
+        identity = _table_identity(table)
+        class_uri = f"{ns_str}{pascal_by_id[identity]}"
         constraints: list[PropertyConstraint] = []
 
         pk_cols: set[str] = set()
@@ -123,7 +127,7 @@ def generate_config_from_db(tables, uri_prefix: str) -> ConstraintConfig:
                         fk_map[col_name] = fk_target
 
         for col in table.columns:
-            prop_path = f"{ns_str}{camel_by_name[table.name]}_{_to_camel(col.name)}"
+            prop_path = f"{ns_str}{camel_by_id[identity]}_{_to_camel(col.name)}"
             is_pk = col.name in pk_cols
             is_not_null = col.constraint in ("NOT_NULL", "PRIMARY_KEY") or is_pk
             is_unique = col.constraint in ("UNIQUE", "PRIMARY_KEY") or col.name in unique_cols or is_pk
@@ -153,7 +157,12 @@ def generate_config_from_db(tables, uri_prefix: str) -> ConstraintConfig:
 
             if is_fk:
                 fk_target_name = fk_map[col.name]
-                target_class = f"{ns_str}{pascal_by_name.get(fk_target_name, _to_pascal(fk_target_name))}"
+                # Resolve through the shared index so the shape targets the same
+                # class the ontology declared and the mapping joins to.
+                qualified = f"{table.sourceSchema}.{fk_target_name}" if table.sourceSchema else None
+                target_id = (qualified and ref_index.get(qualified)) or ref_index.get(fk_target_name)
+                target_local = pascal_by_id[target_id] if target_id in pascal_by_id else _to_pascal(fk_target_name)
+                target_class = f"{ns_str}{target_local}"
                 constraints.append(
                     PropertyConstraint(
                         property_path=prop_path,

--- a/packages/ontology-engine/src/coa_ontology/validation/shapes/config.py
+++ b/packages/ontology-engine/src/coa_ontology/validation/shapes/config.py
@@ -18,6 +18,7 @@ from rdflib.namespace import RDF
 
 # Reuse the canonical SQL→XSD map + naming helpers rather than redefining them
 # (they lived in 3+ places). ``base.py`` owns the authoritative copies.
+from coa_ontology.inducer.services.data_catalog import parse_referred_column
 from coa_ontology.inducer.strategies.base import pascal_names_for as _pascal_names_for
 from coa_ontology.inducer.strategies.base import to_camel as _to_camel
 from coa_ontology.inducer.strategies.base import to_pascal as _to_pascal
@@ -117,9 +118,7 @@ def generate_config_from_db(tables, uri_prefix: str) -> ConstraintConfig:
                 elif tc.constraintType == "UNIQUE" and tc.columns and len(tc.columns) == 1:
                     unique_cols.update(tc.columns)
                 elif tc.constraintType == "FOREIGN_KEY" and tc.columns and tc.referredColumns:
-                    ref = tc.referredColumns[0]
-                    parts = ref.split(".")
-                    fk_target = parts[-2] if len(parts) >= 2 else ref
+                    fk_target, _ = parse_referred_column(tc.referredColumns[0])
                     for col_name in tc.columns:
                         fk_map[col_name] = fk_target
 

--- a/packages/ontology-engine/src/coa_ontology/validation/shapes/config.py
+++ b/packages/ontology-engine/src/coa_ontology/validation/shapes/config.py
@@ -18,6 +18,7 @@ from rdflib.namespace import RDF
 
 # Reuse the canonical SQL→XSD map + naming helpers rather than redefining them
 # (they lived in 3+ places). ``base.py`` owns the authoritative copies.
+from coa_ontology.inducer.strategies.base import pascal_names_for as _pascal_names_for
 from coa_ontology.inducer.strategies.base import to_camel as _to_camel
 from coa_ontology.inducer.strategies.base import to_pascal as _to_pascal
 from coa_ontology.inducer.strategies.base import xsd_for as _xsd_for
@@ -96,8 +97,13 @@ def generate_config_from_db(tables, uri_prefix: str) -> ConstraintConfig:
     ns_str = uri_prefix
     classes: list[ClassConstraints] = []
 
+    # Same collision-resolved local names the ontology and R2RML builders mint,
+    # so the shapes target the classes/properties that actually exist.
+    pascal_by_name = _pascal_names_for(t.name for t in tables)
+    camel_by_name = {n: p[0].lower() + p[1:] if p else p for n, p in pascal_by_name.items()}
+
     for table in tables:
-        class_uri = f"{ns_str}{_to_pascal(table.name)}"
+        class_uri = f"{ns_str}{pascal_by_name[table.name]}"
         constraints: list[PropertyConstraint] = []
 
         pk_cols: set[str] = set()
@@ -118,7 +124,7 @@ def generate_config_from_db(tables, uri_prefix: str) -> ConstraintConfig:
                         fk_map[col_name] = fk_target
 
         for col in table.columns:
-            prop_path = f"{ns_str}{_to_camel(table.name)}_{_to_camel(col.name)}"
+            prop_path = f"{ns_str}{camel_by_name[table.name]}_{_to_camel(col.name)}"
             is_pk = col.name in pk_cols
             is_not_null = col.constraint in ("NOT_NULL", "PRIMARY_KEY") or is_pk
             is_unique = col.constraint in ("UNIQUE", "PRIMARY_KEY") or col.name in unique_cols or is_pk
@@ -147,7 +153,8 @@ def generate_config_from_db(tables, uri_prefix: str) -> ConstraintConfig:
                 )
 
             if is_fk:
-                target_class = f"{ns_str}{_to_pascal(fk_map[col.name])}"
+                fk_target_name = fk_map[col.name]
+                target_class = f"{ns_str}{pascal_by_name.get(fk_target_name, _to_pascal(fk_target_name))}"
                 constraints.append(
                     PropertyConstraint(
                         property_path=prop_path,

--- a/packages/ontology-engine/tests/unit/test_r2rml_spec_compliance.py
+++ b/packages/ontology-engine/tests/unit/test_r2rml_spec_compliance.py
@@ -1026,12 +1026,18 @@ class TestForeignKeyObjectMaps:
         conditions = _object_map_join_conditions(g, ns["TriplesMap_Bookings/POM_BookingDay"])
         assert conditions == [('"booking_day"', '"day"'), ('"booking_hour"', '"hour"')]
 
-        # booking_hour does NOT get its own POM (it's part of the composite)
-        all_poms = list(g.objects(ns.TriplesMap_Bookings, RR.predicateObjectMap))
-        pom_uris = [str(p) for p in all_poms]
-        assert not any("POM_BookingHour" in uri for uri in pom_uris), (
-            "booking_hour should NOT have its own POM — it's part of the composite FK"
+        # booking_hour does NOT get a second REFERENCING map — the relationship is
+        # expressed once, on booking_day (R2RML §7.5).
+        hour_pom = ns["TriplesMap_Bookings/POM_BookingHour"]
+        assert _object_map_parent_tmap(g, hour_pom) is None, (
+            "the composite relationship must be carried by exactly one referencing object map"
         )
+
+        # It DOES get a literal mapping. The ontology declares a property for
+        # every column, so leaving booking_hour unmapped left that declaration
+        # with nothing behind it and any SPARQL using it returned nothing.
+        assert _object_map_column(g, hour_pom) == '"booking_hour"'
+        assert _object_map_datatype(g, hour_pom) == XSD.integer
 
     def test_composite_fk_three_columns(self, strategy):
         """Composite FK with 3 columns produces single POM with 3 joinConditions."""
@@ -2149,3 +2155,203 @@ class TestPascalCaseCollisions:
         shape_classes = {URIRef(c.class_uri) for c in config.classes}
         assert shape_classes <= onto_classes, f"Shapes target absent classes: {shape_classes - onto_classes}"
         assert len(shape_classes) == 2
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# SECTION 11: ontology / R2RML property parity
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+class TestOntologyR2rmlParity:
+    """Every property the ontology declares must have a mapping behind it.
+
+    A declared-but-unmapped property is worse than a missing one: it shows up in
+    the class/property browser and in the TBox context handed to the NL→SPARQL
+    LLM, so the model is encouraged to author SPARQL against a property Ontop
+    cannot resolve. The query compiles and returns nothing, with no mapping-gap
+    signal anywhere.
+    """
+
+    @staticmethod
+    def _declared_properties(onto):
+        return {str(p) for p in onto.subjects(RDF.type, OWL.ObjectProperty)} | {
+            str(p) for p in onto.subjects(RDF.type, OWL.DatatypeProperty)
+        }
+
+    @staticmethod
+    def _mapped_predicates(r2rml):
+        return {str(p) for _, _, p in r2rml.triples((None, RR.predicate, None))}
+
+    def _both(self, strategy, tables):
+        onto, novel = strategy._build_proposal_ontology(PREFIX, tables, [])
+        r2rml = strategy.build_r2rml(PREFIX, tables, novel, onto)
+        return onto, r2rml
+
+    @staticmethod
+    def _composite_fk_tables(*, arity: int = 2):
+        cols = [("day", "VARCHAR"), ("hour", "INT"), ("minute", "INT")][:arity]
+        parent = CatalogTable(
+            id="1",
+            name="time_slots",
+            fullyQualifiedName="s.time_slots",
+            columns=[CatalogColumn(name=n, dataType=t) for n, t in cols]
+            + [CatalogColumn(name="room", dataType="VARCHAR")],
+            tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=[n for n, _ in cols])],
+        )
+        child = CatalogTable(
+            id="2",
+            name="bookings",
+            fullyQualifiedName="s.bookings",
+            columns=[CatalogColumn(name="booking_id", dataType="INT")]
+            + [CatalogColumn(name=n, dataType=t) for n, t in cols]
+            + [CatalogColumn(name="note", dataType="VARCHAR")],
+            tableConstraints=[
+                CatalogConstraint(constraintType="PRIMARY_KEY", columns=["booking_id"]),
+                CatalogConstraint(
+                    constraintType="FOREIGN_KEY",
+                    columns=[n for n, _ in cols],
+                    referredColumns=[f"time_slots.{n}" for n, _ in cols],
+                ),
+            ],
+        )
+        return [parent, child]
+
+    def test_composite_fk_leaves_no_unmapped_property(self, strategy):
+        onto, r2rml = self._both(strategy, self._composite_fk_tables())
+
+        unmapped = self._declared_properties(onto) - self._mapped_predicates(r2rml)
+        assert unmapped == set(), f"ontology declares properties with no R2RML mapping: {sorted(unmapped)}"
+
+    def test_three_column_composite_fk_leaves_no_unmapped_property(self, strategy):
+        """The gap scaled with arity — a 3-column FK orphaned two properties."""
+        onto, r2rml = self._both(strategy, self._composite_fk_tables(arity=3))
+
+        unmapped = self._declared_properties(onto) - self._mapped_predicates(r2rml)
+        assert unmapped == set(), f"ontology declares properties with no R2RML mapping: {sorted(unmapped)}"
+
+    def test_absorbed_column_is_a_datatype_property_not_an_object_property(self, strategy):
+        """The relationship is carried once; the other columns are plain literals."""
+        onto, _ = self._both(strategy, self._composite_fk_tables())
+        ns = Namespace(PREFIX)
+
+        assert (ns.bookings_day, RDF.type, OWL.ObjectProperty) in onto
+        assert (ns.bookings_hour, RDF.type, OWL.DatatypeProperty) in onto
+        assert (ns.bookings_hour, RDF.type, OWL.ObjectProperty) not in onto
+
+    def test_absorbed_column_range_matches_its_r2rml_datatype(self, strategy):
+        """rdfs:range and rr:datatype must agree or Ontop's type reasoning drops rows."""
+        onto, r2rml = self._both(strategy, self._composite_fk_tables())
+        ns = Namespace(PREFIX)
+
+        onto_range = onto.value(ns.bookings_hour, RDFS.range)
+        r2rml_datatype = _object_map_datatype(r2rml, ns["TriplesMap_Bookings/POM_Hour"])
+        assert onto_range == r2rml_datatype == XSD.integer
+
+    def test_absorbed_column_documents_where_the_relationship_lives(self, strategy):
+        onto, _ = self._both(strategy, self._composite_fk_tables())
+        ns = Namespace(PREFIX)
+
+        comment = str(onto.value(ns.bookings_hour, RDFS.comment))
+        assert "composite foreign key" in comment
+        assert "bookings_day" in comment
+
+    # ── malformed composite FKs degrade consistently on BOTH sides ────────────
+
+    @staticmethod
+    def _malformed_tables(*, referred):
+        return [
+            CatalogTable(
+                id="1",
+                name="bookings",
+                fullyQualifiedName="s.bookings",
+                columns=[
+                    CatalogColumn(name="day", dataType="VARCHAR"),
+                    CatalogColumn(name="hour", dataType="INT"),
+                ],
+                tableConstraints=[
+                    CatalogConstraint(
+                        constraintType="FOREIGN_KEY",
+                        columns=["day", "hour"],
+                        referredColumns=referred,
+                    )
+                ],
+            )
+        ]
+
+    def test_length_mismatch_degrades_to_datatype_on_both_sides(self, strategy):
+        """build_r2rml falls back to literals; the ontology must not claim a relationship."""
+        onto, r2rml = self._both(strategy, self._malformed_tables(referred=["slots.day"]))
+        ns = Namespace(PREFIX)
+
+        assert (ns.bookings_day, RDF.type, OWL.DatatypeProperty) in onto
+        assert (ns.bookings_day, RDF.type, OWL.ObjectProperty) not in onto
+        assert onto.value(ns.bookings_day, RDFS.range) == XSD.string
+        assert _object_map_datatype(r2rml, ns["TriplesMap_Bookings/POM_Day"]) == XSD.string
+
+    def test_multi_table_targets_degrade_to_datatype_on_both_sides(self, strategy):
+        onto, r2rml = self._both(strategy, self._malformed_tables(referred=["a.day", "b.hour"]))
+        ns = Namespace(PREFIX)
+
+        for local, expected in (("bookings_day", XSD.string), ("bookings_hour", XSD.integer)):
+            assert (ns[local], RDF.type, OWL.DatatypeProperty) in onto
+            assert onto.value(ns[local], RDFS.range) == expected
+
+    def test_malformed_composite_fk_leaves_no_unmapped_property(self, strategy):
+        onto, r2rml = self._both(strategy, self._malformed_tables(referred=["slots.day"]))
+
+        unmapped = self._declared_properties(onto) - self._mapped_predicates(r2rml)
+        assert unmapped == set(), f"unmapped after malformed-FK fallback: {sorted(unmapped)}"
+
+    # ── the simple cases must be untouched ───────────────────────────────────
+
+    def test_simple_fk_still_yields_an_object_property(self, strategy):
+        tables = [
+            CatalogTable(
+                id="1",
+                name="orders",
+                fullyQualifiedName="s.orders",
+                columns=[
+                    CatalogColumn(name="id", dataType="INT"),
+                    CatalogColumn(name="customer_id", dataType="INT"),
+                ],
+                tableConstraints=[
+                    CatalogConstraint(constraintType="PRIMARY_KEY", columns=["id"]),
+                    CatalogConstraint(
+                        constraintType="FOREIGN_KEY",
+                        columns=["customer_id"],
+                        referredColumns=["customers.id"],
+                    ),
+                ],
+            ),
+            CatalogTable(
+                id="2",
+                name="customers",
+                fullyQualifiedName="s.customers",
+                columns=[CatalogColumn(name="id", dataType="INT")],
+                tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=["id"])],
+            ),
+        ]
+        onto, r2rml = self._both(strategy, tables)
+        ns = Namespace(PREFIX)
+
+        assert (ns.orders_customerId, RDF.type, OWL.ObjectProperty) in onto
+        assert _object_map_parent_tmap(r2rml, ns["TriplesMap_Orders/POM_CustomerId"]) == ns.TriplesMap_Customers
+        assert self._declared_properties(onto) - self._mapped_predicates(r2rml) == set()
+
+    def test_no_fk_table_has_full_parity(self, strategy):
+        tables = [
+            CatalogTable(
+                id="1",
+                name="statuses",
+                fullyQualifiedName="s.statuses",
+                columns=[
+                    CatalogColumn(name="code", dataType="VARCHAR"),
+                    CatalogColumn(name="label", dataType="VARCHAR"),
+                ],
+                tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=["code"])],
+            )
+        ]
+        onto, r2rml = self._both(strategy, tables)
+
+        assert self._declared_properties(onto) - self._mapped_predicates(r2rml) == set()

--- a/packages/ontology-engine/tests/unit/test_r2rml_spec_compliance.py
+++ b/packages/ontology-engine/tests/unit/test_r2rml_spec_compliance.py
@@ -2507,3 +2507,118 @@ class TestReferredColumnParsing:
 
         assert ("loss_payment", "claim_amount") in confirmed
         assert ("expense_payment", "claim_amount") in confirmed
+
+
+@pytest.mark.unit
+class TestOverlappingCompositeForeignKeys:
+    """Two composite FKs sharing a column must both keep their relationship.
+
+    `build_r2rml` walks the columns and CONSUMES each constraint as it anchors it,
+    so for FK1=(a,b)->p1 and FK2=(b,c)->p2: `a` anchors FK1 (absorbing `b`), and
+    `c` — reached with FK1 already consumed — anchors FK2.
+
+    A non-consuming `composite_fk_columns` matched `c` against FK2 while also
+    treating it as absorbed by `b`, so `c` degraded to a literal and the child→p2
+    relationship vanished from the R2RML mapping AND (since both builders share the
+    helper) from the ontology.
+    """
+
+    @staticmethod
+    def _tables():
+        child = CatalogTable(
+            id="1",
+            name="child",
+            fullyQualifiedName="s.child",
+            columns=[
+                CatalogColumn(name="a", dataType="INT"),
+                CatalogColumn(name="b", dataType="INT"),
+                CatalogColumn(name="c", dataType="INT"),
+            ],
+            tableConstraints=[
+                CatalogConstraint(constraintType="FOREIGN_KEY", columns=["a", "b"], referredColumns=["p1.a", "p1.b"]),
+                CatalogConstraint(constraintType="FOREIGN_KEY", columns=["b", "c"], referredColumns=["p2.b", "p2.c"]),
+            ],
+        )
+        p1 = CatalogTable(
+            id="2",
+            name="p1",
+            fullyQualifiedName="s.p1",
+            columns=[CatalogColumn(name="a", dataType="INT"), CatalogColumn(name="b", dataType="INT")],
+            tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=["a", "b"])],
+        )
+        p2 = CatalogTable(
+            id="3",
+            name="p2",
+            fullyQualifiedName="s.p2",
+            columns=[CatalogColumn(name="b", dataType="INT"), CatalogColumn(name="c", dataType="INT")],
+            tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=["b", "c"])],
+        )
+        return [child, p1, p2]
+
+    def test_both_relationships_survive_in_r2rml(self, strategy):
+        g = _build(strategy, self._tables())
+        ns = Namespace(PREFIX)
+
+        parents = {str(p) for _, _, p in g.triples((None, RR.parentTriplesMap, None))}
+        assert str(ns.TriplesMap_P1) in parents
+        assert str(ns.TriplesMap_P2) in parents, "the second composite FK's relationship was dropped"
+
+    def test_each_composite_fk_is_anchored_on_a_distinct_column(self, strategy):
+        g = _build(strategy, self._tables())
+        ns = Namespace(PREFIX)
+
+        assert _object_map_parent_tmap(g, ns["TriplesMap_Child/POM_A"]) == ns.TriplesMap_P1
+        assert _object_map_parent_tmap(g, ns["TriplesMap_Child/POM_C"]) == ns.TriplesMap_P2
+        # b is absorbed by FK1's map and carries a literal mapping only.
+        assert _object_map_parent_tmap(g, ns["TriplesMap_Child/POM_B"]) is None
+        assert _object_map_column(g, ns["TriplesMap_Child/POM_B"]) == '"b"'
+
+    def test_shared_column_is_absorbed_exactly_once(self, strategy):
+        from coa_ontology.inducer.strategies.base import composite_fk_columns
+
+        child = self._tables()[0]
+
+        assert composite_fk_columns(child) == {"b": "a"}
+
+    def test_ontology_matches_the_mapping(self, strategy):
+        tables = self._tables()
+        onto, novel = strategy._build_proposal_ontology(PREFIX, tables, [])
+        r2rml = strategy.build_r2rml(PREFIX, tables, novel, onto)
+        ns = Namespace(PREFIX)
+
+        assert (ns.child_a, RDF.type, OWL.ObjectProperty) in onto
+        assert (ns.child_c, RDF.type, OWL.ObjectProperty) in onto
+        assert (ns.child_b, RDF.type, OWL.DatatypeProperty) in onto
+        assert onto.value(ns.child_c, RDFS.range) == ns.P2
+
+        declared = {str(p) for p in onto.subjects(RDF.type, OWL.ObjectProperty)} | {
+            str(p) for p in onto.subjects(RDF.type, OWL.DatatypeProperty)
+        }
+        mapped = {str(p) for _, _, p in r2rml.triples((None, RR.predicate, None))}
+        assert declared - mapped == set()
+
+    def test_three_overlapping_composite_fks(self, strategy):
+        """Chained overlap: (a,b)->p1, (b,c)->p2, (c,d)->p3."""
+        child = CatalogTable(
+            id="1",
+            name="child",
+            fullyQualifiedName="s.child",
+            columns=[CatalogColumn(name=n, dataType="INT") for n in ("a", "b", "c", "d")],
+            tableConstraints=[
+                CatalogConstraint(constraintType="FOREIGN_KEY", columns=["a", "b"], referredColumns=["p1.a", "p1.b"]),
+                CatalogConstraint(constraintType="FOREIGN_KEY", columns=["b", "c"], referredColumns=["p2.b", "p2.c"]),
+                CatalogConstraint(constraintType="FOREIGN_KEY", columns=["c", "d"], referredColumns=["p3.c", "p3.d"]),
+            ],
+        )
+        g = _build(strategy, [child])
+
+        ns = Namespace(PREFIX)
+        # a anchors FK1 (folding in b); b is skipped as folded, so c anchors FK2
+        # (folding in nothing new); d then anchors FK3. Every constraint keeps a
+        # relationship — matches what the pre-fix mapping emitted, verified by
+        # running both revisions.
+        assert _object_map_parent_tmap(g, ns["TriplesMap_Child/POM_A"]) == ns.TriplesMap_P1
+        assert _object_map_parent_tmap(g, ns["TriplesMap_Child/POM_C"]) == ns.TriplesMap_P2
+        assert _object_map_parent_tmap(g, ns["TriplesMap_Child/POM_D"]) == ns.TriplesMap_P3
+        # b is the only folded column, so it is the only literal.
+        assert _object_map_column(g, ns["TriplesMap_Child/POM_B"]) == '"b"'

--- a/packages/ontology-engine/tests/unit/test_r2rml_spec_compliance.py
+++ b/packages/ontology-engine/tests/unit/test_r2rml_spec_compliance.py
@@ -2078,8 +2078,15 @@ class TestPascalCaseCollisions:
         assert (ns.TriplesMap_Orders, RDF.type, RR.TriplesMap) in g
         assert (ns.TriplesMap_Customers, RDF.type, RR.TriplesMap) in g
 
-    def test_first_colliding_table_keeps_the_bare_iri(self, strategy):
-        """Existing deployments keep byte-identical IRIs for the first name."""
+    def test_the_lowest_identity_keeps_the_bare_iri(self, strategy):
+        """The bare form is assigned by identity, never by input order.
+
+        Order would be the obvious rule and is the wrong one: ``_catalog_to_tables``
+        emits tables in whatever order the catalog enumerated them, so an
+        order-dependent assignment moves the bare IRI to a different table when that
+        order changes and a freshly generated mapping stops matching an
+        already-accepted ontology.
+        """
         tables = self._tables("order_item", "order-item")
         g = _build(strategy, tables)
         ns = Namespace(PREFIX)
@@ -2088,7 +2095,20 @@ class TestPascalCaseCollisions:
         names = [
             str(n) for lt in g.objects(ns.TriplesMap_OrderItem, RR.logicalTable) for n in g.objects(lt, RR.tableName)
         ]
-        assert names == ['"order_item"']
+        # min("db.order-item", "db.order_item") — "-" sorts before "_".
+        assert names == ['"order-item"']
+
+    def test_assignment_does_not_depend_on_input_order(self, strategy):
+        """Reversing the caller's list must mint exactly the same IRIs."""
+        forward = _build(strategy, self._tables("order_item", "order-item"))
+        reverse = _build(strategy, self._tables("order-item", "order_item"))
+
+        assert set(forward.subjects(RDF.type, RR.TriplesMap)) == set(reverse.subjects(RDF.type, RR.TriplesMap))
+        # Not just the same IRIs — the same table behind each one.
+        for tmap in forward.subjects(RDF.type, RR.TriplesMap):
+            fwd = [str(n) for lt in forward.objects(tmap, RR.logicalTable) for n in forward.objects(lt, RR.tableName)]
+            rev = [str(n) for lt in reverse.objects(tmap, RR.logicalTable) for n in reverse.objects(lt, RR.tableName)]
+            assert fwd == rev, f"{tmap} maps {fwd} one way and {rev} the other"
 
     def test_assignment_is_deterministic_across_runs(self, strategy):
         """Same input order must mint the same IRIs every time."""
@@ -2622,3 +2642,246 @@ class TestOverlappingCompositeForeignKeys:
         assert _object_map_parent_tmap(g, ns["TriplesMap_Child/POM_D"]) == ns.TriplesMap_P3
         # b is the only folded column, so it is the only literal.
         assert _object_map_column(g, ns["TriplesMap_Child/POM_B"]) == '"b"'
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# SECTION 13: A column in a malformed FK that also anchors a well-formed one
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestMalformedAndUsableCompositeFksShareAColumn:
+    """A broken constraint must not cost an unrelated, expressible relationship.
+
+    ``build_r2rml`` degrades every column of a malformed composite FK to a literal,
+    and ``composite_fk_anchors`` assigns anchors for the usable ones. A column can be
+    in both sets. The malformed check used to run FIRST, so such a column was emitted
+    as ``rr:column`` + ``rr:datatype`` — while the ontology, which asks
+    ``composite_fk_anchors``, still declared it an ``owl:ObjectProperty`` with
+    ``rdfs:range <Parent>``. That is the ontology/mapping contradiction the
+    composite-FK work set out to remove, reintroduced through a different door, and
+    it silently dropped the usable FK's relationship from the mapping entirely: the
+    anchor was consumed, so no other column re-emitted it.
+    """
+
+    @staticmethod
+    def _tables():
+        # Column order matters: `c` must be the first column of a usable composite
+        # FK so `composite_fk_anchors` picks it as the anchor.
+        child = CatalogTable(
+            id="1",
+            name="child",
+            fullyQualifiedName="s.child",
+            columns=[CatalogColumn(name=n, dataType="INT") for n in ("c", "a", "d")],
+            tableConstraints=[
+                # Malformed: two columns, one referred column — no join derivable.
+                CatalogConstraint(constraintType="FOREIGN_KEY", columns=["c", "d"], referredColumns=["broken.x"]),
+                # Usable: anchored on `c`, folding in `a`.
+                CatalogConstraint(
+                    constraintType="FOREIGN_KEY", columns=["c", "a"], referredColumns=["good.px", "good.py"]
+                ),
+            ],
+        )
+        good = CatalogTable(
+            id="2",
+            name="good",
+            fullyQualifiedName="s.good",
+            columns=[CatalogColumn(name=n, dataType="INT") for n in ("px", "py")],
+            tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=["px", "py"])],
+        )
+        return [child, good]
+
+    def test_the_usable_relationship_survives(self, strategy):
+        g = _build(strategy, self._tables())
+        ns = Namespace(PREFIX)
+        pom = ns["TriplesMap_Child/POM_C"]
+
+        assert _object_map_parent_tmap(g, pom) == ns.TriplesMap_Good
+        assert _object_map_join_conditions(g, pom) == [('"a"', '"py"'), ('"c"', '"px"')]
+
+    def test_the_anchor_is_not_degraded_to_a_literal(self, strategy):
+        g = _build(strategy, self._tables())
+        ns = Namespace(PREFIX)
+        pom = ns["TriplesMap_Child/POM_C"]
+
+        assert _object_map_datatype(g, pom) is None
+        assert _object_map_column(g, pom) is None
+
+    def test_a_column_only_in_the_malformed_fk_still_degrades(self, strategy):
+        """The malformed constraint is still unmappable — `d` must stay a literal."""
+        g = _build(strategy, self._tables())
+        ns = Namespace(PREFIX)
+        pom = ns["TriplesMap_Child/POM_D"]
+
+        assert _object_map_column(g, pom) == '"d"'
+        assert _object_map_parent_tmap(g, pom) is None
+
+    def test_range_and_datatype_do_not_contradict(self, strategy):
+        """The invariant that actually broke: rdfs:range vs rr:datatype."""
+        tables = self._tables()
+        onto, novel = strategy._build_proposal_ontology(PREFIX, tables, [])
+        r2rml = strategy.build_r2rml(PREFIX, tables, novel, onto)
+        ns = Namespace(PREFIX)
+
+        # The ontology declares an object property pointing at the USABLE FK's
+        # parent — not at `broken`, which the first-matching-constraint lookup used
+        # to return because the malformed constraint is listed first.
+        assert (ns.child_c, RDF.type, OWL.ObjectProperty) in onto
+        assert onto.value(ns.child_c, RDFS.range) == ns.Good
+
+        # And the mapping agrees: a referencing object map, no rr:datatype.
+        pom = ns["TriplesMap_Child/POM_C"]
+        assert _object_map_parent_tmap(r2rml, pom) == ns.TriplesMap_Good
+        assert _object_map_datatype(r2rml, pom) is None
+
+        # `d` is a literal in both artifacts.
+        assert (ns.child_d, RDF.type, OWL.DatatypeProperty) in onto
+        assert _object_map_datatype(r2rml, ns["TriplesMap_Child/POM_D"]) == XSD.integer
+
+    def test_every_declared_property_is_still_mapped(self, strategy):
+        tables = self._tables()
+        onto, novel = strategy._build_proposal_ontology(PREFIX, tables, [])
+        r2rml = strategy.build_r2rml(PREFIX, tables, novel, onto)
+
+        declared = {str(p) for p in onto.subjects(RDF.type, OWL.ObjectProperty)} | {
+            str(p) for p in onto.subjects(RDF.type, OWL.DatatypeProperty)
+        }
+        mapped = {str(p) for _, _, p in r2rml.triples((None, RR.predicate, None))}
+        assert declared - mapped == set()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# SECTION 14: Same table name in two databases
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestSameNameInDifferentDatabases:
+    """Two tables sharing a bare name are two tables.
+
+    One induction flattens every database of every requested datasource into a
+    single list (``_catalog_to_tables`` fills ``name`` from the bare table name and
+    puts the qualified form in ``fullyQualifiedName``), so ``public.customers`` and
+    ``analytics.customers`` arrive as two entries both named ``customers``. Keying
+    the local-name helper on the NAME collapsed them: one TriplesMap with two
+    ``rr:logicalTable`` / ``rr:tableName`` values — invalid R2RML, the same defect
+    the separator/case collisions produced, reached by a different route.
+    """
+
+    @staticmethod
+    def _tables():
+        return [
+            CatalogTable(
+                id=f"{schema}.customers",
+                name="customers",
+                fullyQualifiedName=f"{schema}.customers",
+                sourceSchema=schema,
+                columns=[CatalogColumn(name="id", dataType="INT")],
+                tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=["id"])],
+            )
+            for schema in ("public", "analytics")
+        ]
+
+    def test_two_triples_maps(self, strategy):
+        g = _build(strategy, self._tables())
+
+        assert len(set(g.subjects(RDF.type, RR.TriplesMap))) == 2
+
+    def test_each_triples_map_has_exactly_one_table_name(self, strategy):
+        """The R2RML invariant (§2.2: a TriplesMap has one logical table)."""
+        g = _build(strategy, self._tables())
+
+        for tmap in g.subjects(RDF.type, RR.TriplesMap):
+            logical_tables = list(g.objects(tmap, RR.logicalTable))
+            assert len(logical_tables) == 1, f"{tmap} has {len(logical_tables)} logical tables"
+            names = [str(n) for lt in logical_tables for n in g.objects(lt, RR.tableName)]
+            assert len(names) == 1, f"{tmap} maps {len(names)} tables: {names}"
+
+    def test_two_classes(self, strategy):
+        tables = self._tables()
+        onto, _ = strategy._build_proposal_ontology(PREFIX, tables, [])
+
+        classes = {str(c) for c in onto.subjects(RDF.type, OWL.Class)}
+        assert len([c for c in classes if "Customers" in c]) == 2, classes
+
+    def test_the_ontology_and_the_mapping_name_the_same_classes(self, strategy):
+        tables = self._tables()
+        onto, novel = strategy._build_proposal_ontology(PREFIX, tables, [])
+        r2rml = strategy.build_r2rml(PREFIX, tables, novel, onto)
+
+        declared = {str(c) for c in onto.subjects(RDF.type, OWL.Class)}
+        mapped = {str(c) for _, _, c in r2rml.triples((None, RR["class"], None))}
+        assert mapped <= declared, mapped - declared
+
+    def test_an_fk_resolves_within_its_own_schema(self, strategy):
+        """An ambiguous bare target must not join to the other database's table."""
+        tables = self._tables()
+        tables.append(
+            CatalogTable(
+                id="public.orders",
+                name="orders",
+                fullyQualifiedName="public.orders",
+                sourceSchema="public",
+                columns=[CatalogColumn(name="customer_id", dataType="INT")],
+                tableConstraints=[
+                    CatalogConstraint(
+                        constraintType="FOREIGN_KEY", columns=["customer_id"], referredColumns=["customers.id"]
+                    )
+                ],
+            )
+        )
+        g = _build(strategy, tables)
+        ns = Namespace(PREFIX)
+
+        parent = _object_map_parent_tmap(g, ns["TriplesMap_Orders/POM_CustomerId"])
+        assert parent is not None
+        assert str(parent).startswith(f"{PREFIX}TriplesMap_Customers")
+        # The FK must follow the referrer's own schema, not whichever same-named
+        # table happens to be reachable by bare name.
+        parent_schema = g.value(parent, SCL.sourceSchema)
+        assert str(parent_schema) == "public", f"FK left its own schema: {parent_schema}"
+
+    def test_a_unique_bare_name_still_resolves(self, strategy):
+        """The bare-name path must keep working when there is no ambiguity."""
+        tables = [
+            CatalogTable(
+                id="public.customers",
+                name="customers",
+                fullyQualifiedName="public.customers",
+                sourceSchema="public",
+                columns=[CatalogColumn(name="id", dataType="INT")],
+                tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=["id"])],
+            ),
+            CatalogTable(
+                id="analytics.orders",
+                name="orders",
+                fullyQualifiedName="analytics.orders",
+                sourceSchema="analytics",
+                columns=[CatalogColumn(name="customer_id", dataType="INT")],
+                tableConstraints=[
+                    CatalogConstraint(
+                        constraintType="FOREIGN_KEY", columns=["customer_id"], referredColumns=["customers.id"]
+                    )
+                ],
+            ),
+        ]
+        g = _build(strategy, tables)
+        ns = Namespace(PREFIX)
+
+        # Cross-schema, but unambiguous: resolve it rather than dropping the join.
+        assert _object_map_parent_tmap(g, ns["TriplesMap_Orders/POM_CustomerId"]) == ns.TriplesMap_Customers
+
+    def test_a_single_table_keeps_its_bare_iri(self, strategy):
+        """IRI stability: qualifying the identity must not change the local name."""
+        tables = [
+            CatalogTable(
+                id="public.customers",
+                name="customers",
+                fullyQualifiedName="public.customers",
+                sourceSchema="public",
+                columns=[CatalogColumn(name="id", dataType="INT")],
+                tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=["id"])],
+            )
+        ]
+        g = _build(strategy, tables)
+        ns = Namespace(PREFIX)
+
+        assert (ns.TriplesMap_Customers, RDF.type, RR.TriplesMap) in g

--- a/packages/ontology-engine/tests/unit/test_r2rml_spec_compliance.py
+++ b/packages/ontology-engine/tests/unit/test_r2rml_spec_compliance.py
@@ -25,7 +25,7 @@ from coa_ontology.inducer.services.data_catalog import (
     CatalogTable,
 )
 from coa_ontology.inducer.strategies.base import RR, SCL
-from rdflib import RDF, XSD, Graph, Namespace
+from rdflib import OWL, RDF, RDFS, XSD, Graph, Namespace, URIRef
 
 pytestmark = pytest.mark.unit
 
@@ -1995,3 +1995,157 @@ class TestEdgeCases:
         # First FK constraint wins — parentTriplesMap points to table_a
         parent = _object_map_parent_tmap(g, ns["TriplesMap_Refs/POM_TargetId"])
         assert parent == ns.TriplesMap_TableA
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# SECTION 10: IRI collision resolution (to_pascal is lossy)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+class TestPascalCaseCollisions:
+    """Distinct tables must never share a class / TriplesMap IRI.
+
+    ``to_pascal`` folds separators and case, so names like ``order_item`` and
+    ``order-item`` collapse onto one local name. Minting IRIs from it directly
+    fused the two tables: one TriplesMap carrying two ``rr:tableName`` values
+    (invalid R2RML — a TriplesMap has exactly one logical table) and one class
+    carrying both tables' labels and key axioms.
+    """
+
+    @staticmethod
+    def _tables(*names):
+        return [
+            CatalogTable(
+                id=str(i),
+                name=name,
+                fullyQualifiedName=f"db.{name}",
+                columns=[CatalogColumn(name="id", dataType="INT")],
+                tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=["id"])],
+            )
+            for i, name in enumerate(names, start=1)
+        ]
+
+    def test_separator_variants_get_distinct_triples_maps(self, strategy):
+        tables = self._tables("order_item", "order-item")
+        g = _build(strategy, tables)
+
+        tmaps = set(g.subjects(RDF.type, RR.TriplesMap))
+        assert len(tmaps) == 2, f"Expected one TriplesMap per table, got {tmaps}"
+
+    def test_each_triples_map_has_exactly_one_table_name(self, strategy):
+        """The R2RML invariant that the collision broke."""
+        tables = self._tables("order_item", "order-item")
+        g = _build(strategy, tables)
+
+        for tmap in g.subjects(RDF.type, RR.TriplesMap):
+            logical_tables = list(g.objects(tmap, RR.logicalTable))
+            assert len(logical_tables) == 1, f"{tmap} has {len(logical_tables)} logical tables"
+            names = [str(n) for lt in logical_tables for n in g.objects(lt, RR.tableName)]
+            assert len(names) == 1, f"{tmap} maps {len(names)} tables: {names}"
+
+    def test_both_source_tables_are_mapped(self, strategy):
+        """Neither table may be silently dropped by the disambiguation."""
+        tables = self._tables("order_item", "order-item")
+        g = _build(strategy, tables)
+
+        mapped = {
+            str(n)
+            for tmap in g.subjects(RDF.type, RR.TriplesMap)
+            for lt in g.objects(tmap, RR.logicalTable)
+            for n in g.objects(lt, RR.tableName)
+        }
+        assert mapped == {'"order_item"', '"order-item"'}
+
+    def test_case_only_variants_get_distinct_triples_maps(self, strategy):
+        tables = self._tables("Customer", "customer")
+        g = _build(strategy, tables)
+
+        assert len(set(g.subjects(RDF.type, RR.TriplesMap))) == 2
+
+    def test_non_colliding_names_keep_bare_pascal_iris(self, strategy):
+        """No discriminator when there is nothing to disambiguate (IRI stability)."""
+        tables = self._tables("orders", "customers")
+        g = _build(strategy, tables)
+        ns = Namespace(PREFIX)
+
+        assert (ns.TriplesMap_Orders, RDF.type, RR.TriplesMap) in g
+        assert (ns.TriplesMap_Customers, RDF.type, RR.TriplesMap) in g
+
+    def test_first_colliding_table_keeps_the_bare_iri(self, strategy):
+        """Existing deployments keep byte-identical IRIs for the first name."""
+        tables = self._tables("order_item", "order-item")
+        g = _build(strategy, tables)
+        ns = Namespace(PREFIX)
+
+        assert (ns.TriplesMap_OrderItem, RDF.type, RR.TriplesMap) in g
+        names = [
+            str(n) for lt in g.objects(ns.TriplesMap_OrderItem, RR.logicalTable) for n in g.objects(lt, RR.tableName)
+        ]
+        assert names == ['"order_item"']
+
+    def test_assignment_is_deterministic_across_runs(self, strategy):
+        """Same input order must mint the same IRIs every time."""
+        first = _build(strategy, self._tables("order_item", "order-item"))
+        second = _build(strategy, self._tables("order_item", "order-item"))
+
+        assert set(first.subjects(RDF.type, RR.TriplesMap)) == set(second.subjects(RDF.type, RR.TriplesMap))
+
+    def test_ontology_and_r2rml_agree_on_class_iris(self, strategy):
+        """The two builders must mint identical class IRIs for colliding names."""
+        tables = self._tables("order_item", "order-item")
+        onto, novel = strategy._build_proposal_ontology(PREFIX, tables, [])
+        r2rml = strategy.build_r2rml(PREFIX, tables, novel, onto)
+
+        onto_classes = set(onto.subjects(RDF.type, OWL.Class))
+        r2rml_classes = {c for _, _, c in r2rml.triples((None, RR["class"], None))}
+        assert r2rml_classes <= onto_classes, (
+            f"R2RML references classes absent from the ontology: {r2rml_classes - onto_classes}"
+        )
+        assert len(r2rml_classes) == 2
+
+    def test_ontology_gives_each_table_its_own_class_and_label(self, strategy):
+        tables = self._tables("order_item", "order-item")
+        onto, _ = strategy._build_proposal_ontology(PREFIX, tables, [])
+
+        labels_by_class = {
+            str(cls): sorted(str(lbl) for lbl in onto.objects(cls, RDFS.label))
+            for cls in onto.subjects(RDF.type, OWL.Class)
+        }
+        assert len(labels_by_class) == 2
+        for cls, labels in labels_by_class.items():
+            assert len(labels) == 1, f"{cls} carries labels from multiple tables: {labels}"
+
+    def test_colliding_tables_get_distinct_property_iris(self, strategy):
+        """Discriminated classes must carry discriminated property IRIs too."""
+        tables = [
+            CatalogTable(
+                id="1",
+                name="order_item",
+                fullyQualifiedName="db.order_item",
+                columns=[CatalogColumn(name="qty", dataType="INT")],
+            ),
+            CatalogTable(
+                id="2",
+                name="order-item",
+                fullyQualifiedName="db.order-item",
+                columns=[CatalogColumn(name="qty", dataType="INT")],
+            ),
+        ]
+        g = _build(strategy, tables)
+
+        predicates = {str(p) for _, _, p in g.triples((None, RR.predicate, None))}
+        assert len(predicates) == 2, f"Property IRIs still collide: {predicates}"
+
+    def test_shacl_config_agrees_with_ontology_class_iris(self, strategy):
+        """generate_config_from_db must target the classes the ontology declares."""
+        from coa_ontology.validation.shapes.config import generate_config_from_db
+
+        tables = self._tables("order_item", "order-item")
+        onto, _ = strategy._build_proposal_ontology(PREFIX, tables, [])
+        config = generate_config_from_db(tables, PREFIX)
+
+        onto_classes = set(onto.subjects(RDF.type, OWL.Class))
+        shape_classes = {URIRef(c.class_uri) for c in config.classes}
+        assert shape_classes <= onto_classes, f"Shapes target absent classes: {shape_classes - onto_classes}"
+        assert len(shape_classes) == 2

--- a/packages/ontology-engine/tests/unit/test_r2rml_spec_compliance.py
+++ b/packages/ontology-engine/tests/unit/test_r2rml_spec_compliance.py
@@ -943,14 +943,14 @@ class TestForeignKeyObjectMaps:
         col = _object_map_column(g, ns["TriplesMap_Invoices/POM_OrderRef"])
         assert col == '"order_ref"'
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Three-part referredColumns ('schema.table.column') extracts schema as target — not supported",
-    )
     def test_referred_columns_three_part_schema_table_column(self, strategy):
-        """Future-proofing: referredColumns as 'schema.table.column'.
-        parts[0] extracts 'schema' — this is WRONG. The correct target is parts[1]
-        (the table name). Marked xfail so a future fix auto-promotes."""
+        """referredColumns as 'schema.table.column' resolves to the TABLE, not the schema.
+
+        Was xfail: the R2RML builder took ``parts[0]`` (the schema) while the
+        ontology, the SHACL config, and the subtype detector all took
+        ``parts[-2]`` (the table), so the mapping pointed at a TriplesMap that does
+        not exist. All six call sites now share ``parse_referred_column``.
+        """
         tables = [
             CatalogTable(
                 id="1",
@@ -2355,3 +2355,155 @@ class TestOntologyR2rmlParity:
         onto, r2rml = self._both(strategy, tables)
 
         assert self._declared_properties(onto) - self._mapped_predicates(r2rml) == set()
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# SECTION 12: referredColumns parsing is one shared rule
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.unit
+class TestReferredColumnParsing:
+    """All consumers must resolve an FK target identically.
+
+    The rule was re-implemented at six call sites under two incompatible
+    conventions: `parts[0]` in the R2RML builder and the RIGOR topological sort,
+    `parts[-2]` in the ontology builder, the SHACL config, the subtype detector,
+    and the fingerprint normalizer. For `schema.table.column` the former yields
+    the SCHEMA, so the mapping referenced a nonexistent TriplesMap while the
+    ontology and shapes correctly referenced the table.
+    """
+
+    @pytest.mark.parametrize(
+        ("ref", "expected"),
+        [
+            ("orders.order_id", ("orders", "order_id")),
+            ("public.orders.order_id", ("orders", "order_id")),
+            ("db.public.orders.order_id", ("orders", "order_id")),
+            ("orders", ("orders", None)),
+        ],
+    )
+    def test_parser_keeps_the_trailing_table_and_column(self, ref, expected):
+        from coa_ontology.inducer.services.data_catalog import parse_referred_column
+
+        assert parse_referred_column(ref) == expected
+
+    @staticmethod
+    def _schema_qualified_tables():
+        return [
+            CatalogTable(
+                id="1",
+                name="invoices",
+                fullyQualifiedName="billing.invoices",
+                columns=[CatalogColumn(name="order_ref", dataType="INT")],
+                tableConstraints=[
+                    CatalogConstraint(
+                        constraintType="FOREIGN_KEY",
+                        columns=["order_ref"],
+                        referredColumns=["public.orders.order_id"],
+                    )
+                ],
+            ),
+            CatalogTable(
+                id="2",
+                name="orders",
+                fullyQualifiedName="public.orders",
+                columns=[CatalogColumn(name="order_id", dataType="INT")],
+                tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=["order_id"])],
+            ),
+        ]
+
+    def test_r2rml_and_ontology_agree_on_a_schema_qualified_target(self, strategy):
+        tables = self._schema_qualified_tables()
+        onto, novel = strategy._build_proposal_ontology(PREFIX, tables, [])
+        r2rml = strategy.build_r2rml(PREFIX, tables, novel, onto)
+        ns = Namespace(PREFIX)
+
+        # Ontology: range is the TABLE's class, never a class named after the schema
+        assert onto.value(ns.invoices_orderRef, RDFS.range) == ns.Orders
+        # R2RML: parent is the TABLE's TriplesMap
+        parent = _object_map_parent_tmap(r2rml, ns["TriplesMap_Invoices/POM_OrderRef"])
+        assert parent == ns.TriplesMap_Orders
+
+    def test_shacl_config_agrees_on_a_schema_qualified_target(self, strategy):
+        from coa_ontology.validation.shapes.config import generate_config_from_db
+
+        config = generate_config_from_db(self._schema_qualified_tables(), PREFIX)
+
+        targets = [
+            c.params.get("target_class")
+            for cls in config.classes
+            for c in cls.constraints
+            if c.params and "target_class" in c.params
+        ]
+        assert targets == [f"{PREFIX}Orders"]
+
+    def test_no_class_is_minted_from_the_schema_name(self, strategy):
+        tables = self._schema_qualified_tables()
+        onto, _ = strategy._build_proposal_ontology(PREFIX, tables, [])
+
+        classes = {str(c) for c in onto.subjects(RDF.type, OWL.Class)}
+        assert f"{PREFIX}Public" not in classes
+
+    def test_join_condition_uses_the_trailing_column(self, strategy):
+        tables = self._schema_qualified_tables()
+        g = _build(strategy, tables)
+        ns = Namespace(PREFIX)
+
+        conditions = _object_map_join_conditions(g, ns["TriplesMap_Invoices/POM_OrderRef"])
+        assert conditions == [('"order_ref"', '"order_id"')]
+
+    def test_fingerprint_treats_qualified_and_bare_refs_as_equal(self):
+        """A rescan reporting a longer qualification must not look like a new schema."""
+        from coa_ontology.induce_catalog import _compute_structural_fingerprint
+
+        def _tables(ref):
+            return [
+                CatalogTable(
+                    id="1",
+                    name="invoices",
+                    fullyQualifiedName="billing.invoices",
+                    columns=[CatalogColumn(name="order_ref", dataType="INT")],
+                    tableConstraints=[
+                        CatalogConstraint(constraintType="FOREIGN_KEY", columns=["order_ref"], referredColumns=[ref])
+                    ],
+                )
+            ]
+
+        bare = _compute_structural_fingerprint(_tables("orders.order_id"))
+        qualified = _compute_structural_fingerprint(_tables("db.public.orders.order_id"))
+        assert bare == qualified
+
+    def test_subtype_detection_handles_a_schema_qualified_self_reference(self):
+        """PK-sharing detection must resolve the parent table, not the schema."""
+        from coa_ontology.inducer.services.subtype_detection import detect_pk_sharing_subtypes
+
+        parent = CatalogTable(
+            id="1",
+            name="claim_amount",
+            fullyQualifiedName="ins.claim_amount",
+            columns=[CatalogColumn(name="claim_id", dataType="INT")],
+            tableConstraints=[CatalogConstraint(constraintType="PRIMARY_KEY", columns=["claim_id"])],
+        )
+        children = [
+            CatalogTable(
+                id=str(i + 2),
+                name=name,
+                fullyQualifiedName=f"ins.{name}",
+                columns=[CatalogColumn(name="claim_id", dataType="INT")],
+                tableConstraints=[
+                    CatalogConstraint(constraintType="PRIMARY_KEY", columns=["claim_id"]),
+                    CatalogConstraint(
+                        constraintType="FOREIGN_KEY",
+                        columns=["claim_id"],
+                        referredColumns=["ins.claim_amount.claim_id"],
+                    ),
+                ],
+            )
+            for i, name in enumerate(("loss_payment", "expense_payment"))
+        ]
+
+        confirmed, _suggested = detect_pk_sharing_subtypes([parent, *children])
+
+        assert ("loss_payment", "claim_amount") in confirmed
+        assert ("expense_payment", "claim_amount") in confirmed


### PR DESCRIPTION
Split from #19 (10/11). Fixes #14, fixes #15, fixes #16.

These three stay grouped because they share `inducer/strategies/base.py` and one test module (`test_r2rml_spec_compliance.py`):

- #14 — table IRIs are keyed on identity, so `order_item` and `order-item` no longer fuse into one class/TriplesMap; PascalCase collisions are resolved instead of merged.
- #15 — FK `referredColumns` are parsed by one shared rule across R2RML, ontology, SHACL, and subtype detection, so schema-qualified refs map to the right TriplesMap.
- #16 — every declared ObjectProperty of a composite FK gets an R2RML mapping, and a usable composite FK wins over overlapping single-column constraints.

File-disjoint from every other PR in the split.
