### PR TITLE
fix(authz): namespace-scoped restrictions, full grant pagination

### DIFF
--- a/libs/common/src/coa_common/dao/base.py
+++ b/libs/common/src/coa_common/dao/base.py
@@ -81,6 +81,49 @@ class DatastoreDAO(ABC):
     def query(self, params: QueryParams) -> PaginatedResult:
         """Query items using a key condition expression."""
 
+    def query_all(self, params: QueryParams, *, max_pages: int = 100) -> list[dict[str, Any]]:
+        """Query every matching item, following the pagination cursor to exhaustion.
+
+        :meth:`query` returns ONE page. DynamoDB caps a response at 1 MB
+        regardless of how many items match, so a caller that reads
+        ``result.items`` and stops silently truncates its result set with no
+        error — the failure mode is invisible at the call site. That is merely a
+        short list for a listing endpoint, but for authorization data it means
+        roles or data restrictions disappear, so every authorization-critical
+        read must use this method rather than ``query``.
+
+        ``params.limit`` is left untouched (it bounds each page, not the total).
+        Any ``exclusive_start_key`` on ``params`` is honoured as the starting
+        cursor.
+
+        Args:
+            params: Query parameters; the cursor is advanced internally.
+            max_pages: Safety bound on pages read. Reaching it raises rather than
+                returning a partial set — a silent truncation here is exactly the
+                bug this method exists to prevent, and a partition needing more
+                than this indicates a data-model problem worth surfacing.
+
+        Returns:
+            Every matching item across all pages.
+
+        Raises:
+            RuntimeError: If ``max_pages`` is exhausted while a cursor remains.
+        """
+        from dataclasses import replace
+
+        items: list[dict[str, Any]] = []
+        page_params = params
+        for _ in range(max_pages):
+            page = self.query(page_params)
+            items.extend(page.items)
+            if not page.last_evaluated_key:
+                return items
+            page_params = replace(page_params, exclusive_start_key=page.last_evaluated_key)
+        raise RuntimeError(
+            f"query_all exceeded {max_pages} pages without exhausting the cursor "
+            f"(index={params.index_name!r}); refusing to return a partial result set"
+        )
+
     @abstractmethod
     def atomic_increment(
         self,

--- a/libs/common/tests/unit/test_dao.py
+++ b/libs/common/tests/unit/test_dao.py
@@ -239,6 +239,108 @@ class TestDynamoDBDAOQuery:
         assert call_args["Limit"] == 10
 
 
+class TestDynamoDBDAOQueryAll:
+    """query_all must follow LastEvaluatedKey to exhaustion.
+
+    DynamoDB caps a query response at 1 MB regardless of how many items match, so
+    a caller reading only ``result.items`` silently truncates. For authorization
+    reads that means roles / data restrictions disappear with no error.
+    """
+
+    def test_follows_pagination_cursor_across_pages(self, mock_table):
+        table, _ = mock_table
+        table.query.side_effect = [
+            {"Items": [{"PK": "a"}], "LastEvaluatedKey": {"PK": "a"}},
+            {"Items": [{"PK": "b"}], "LastEvaluatedKey": {"PK": "b"}},
+            {"Items": [{"PK": "c"}]},
+        ]
+
+        dao = DynamoDBDAO("test-table", region="us-east-1")
+        items = dao.query_all(QueryParams(key_condition="PK = :pk", expression_values={":pk": "x"}))
+
+        assert [i["PK"] for i in items] == ["a", "b", "c"]
+        assert table.query.call_count == 3
+
+    def test_passes_cursor_as_exclusive_start_key(self, mock_table):
+        table, _ = mock_table
+        table.query.side_effect = [
+            {"Items": [{"PK": "a"}], "LastEvaluatedKey": {"PK": "a", "SK": "s"}},
+            {"Items": [{"PK": "b"}]},
+        ]
+
+        dao = DynamoDBDAO("test-table", region="us-east-1")
+        dao.query_all(QueryParams(key_condition="PK = :pk", expression_values={":pk": "x"}))
+
+        assert table.query.call_args_list[1].kwargs["ExclusiveStartKey"] == {"PK": "a", "SK": "s"}
+
+    def test_single_page_makes_one_call(self, mock_table):
+        table, _ = mock_table
+        table.query.return_value = {"Items": [{"PK": "a"}]}
+
+        dao = DynamoDBDAO("test-table", region="us-east-1")
+        items = dao.query_all(QueryParams(key_condition="PK = :pk", expression_values={":pk": "x"}))
+
+        assert len(items) == 1
+        assert table.query.call_count == 1
+
+    def test_empty_result(self, mock_table):
+        table, _ = mock_table
+        table.query.return_value = {"Items": []}
+
+        dao = DynamoDBDAO("test-table", region="us-east-1")
+        assert dao.query_all(QueryParams(key_condition="PK = :pk", expression_values={":pk": "x"})) == []
+
+    def test_preserves_index_and_expression_names_on_every_page(self, mock_table):
+        table, _ = mock_table
+        table.query.side_effect = [
+            {"Items": [{"PK": "a"}], "LastEvaluatedKey": {"PK": "a"}},
+            {"Items": [{"PK": "b"}]},
+        ]
+
+        dao = DynamoDBDAO("test-table", region="us-east-1")
+        dao.query_all(
+            QueryParams(
+                key_condition="#pk = :pk",
+                expression_values={":pk": "x"},
+                expression_names={"#pk": "principalKey"},
+                index_name="PrincipalIndex",
+            )
+        )
+
+        for call in table.query.call_args_list:
+            assert call.kwargs["IndexName"] == "PrincipalIndex"
+            assert call.kwargs["ExpressionAttributeNames"] == {"#pk": "principalKey"}
+
+    def test_honours_a_caller_supplied_start_cursor(self, mock_table):
+        table, _ = mock_table
+        table.query.return_value = {"Items": [{"PK": "b"}]}
+
+        dao = DynamoDBDAO("test-table", region="us-east-1")
+        dao.query_all(
+            QueryParams(
+                key_condition="PK = :pk",
+                expression_values={":pk": "x"},
+                exclusive_start_key={"PK": "a"},
+            )
+        )
+
+        assert table.query.call_args.kwargs["ExclusiveStartKey"] == {"PK": "a"}
+
+    def test_raises_rather_than_returning_a_partial_set(self, mock_table):
+        """Hitting the page bound must fail loudly — silent truncation is the bug."""
+        table, _ = mock_table
+        table.query.return_value = {"Items": [{"PK": "a"}], "LastEvaluatedKey": {"PK": "a"}}
+
+        dao = DynamoDBDAO("test-table", region="us-east-1")
+        with pytest.raises(RuntimeError, match="without exhausting the cursor"):
+            dao.query_all(
+                QueryParams(key_condition="PK = :pk", expression_values={":pk": "x"}),
+                max_pages=3,
+            )
+
+        assert table.query.call_count == 3
+
+
 class TestDynamoDBDAOBatchGet:
     def test_batch_get(self, mock_table):
         _, mock_resource = mock_table

--- a/packages/context-manager/src/coa_serve/role_resolver.py
+++ b/packages/context-manager/src/coa_serve/role_resolver.py
@@ -125,10 +125,20 @@ def _merge_data_restrictions(
       If ANY grant has no allowlist, the user has unrestricted table access.
     - columnDenylist: INTERSECTION across all matching grants (most permissive).
       A column is denied only if ALL matching grants deny it.
+
+    Scoped to grants on THIS namespace. A ``GLOBAL``-scoped grant (the shape
+    platform-admin / platform-viewer are written with) must NOT participate:
+    platform grants carry no tableAllowlist/columnDenylist fields, so the
+    "any grant without a restriction means unrestricted" rule above would fire
+    on them and erase the namespace grant's restrictions entirely — a user who
+    holds both a restricted namespace role and a platform role would get
+    unrestricted data access, and the SQL firewall would log the query as
+    ``restricted=False`` (no trace of a bypass). Platform privileges still flow
+    through ``result.global_roles``, which is resolved separately in
+    ``resolve_profile`` and drives the Cedar action-level layer; only the
+    data-level merge is namespace-scoped.
     """
-    namespace_grants = [
-        item for item in items if item.get("resourceId") == namespace or item.get("resourceId") == "GLOBAL"
-    ]
+    namespace_grants = [item for item in items if item.get("resourceId") == namespace]
 
     if not namespace_grants:
         return
@@ -160,9 +170,6 @@ def _merge_data_restrictions(
 
     if not has_unrestricted_metrics and merged_metrics:
         result.allowed_metrics = sorted(merged_metrics)
-
-    if not has_unrestricted_grant and merged_tables:
-        result.table_allowlist = sorted(merged_tables)
 
     # Column denylist: intersection (only deny if ALL grants deny it)
     denylist_sets: list[dict[str, set[str]]] = []

--- a/packages/context-manager/src/coa_serve/role_resolver.py
+++ b/packages/context-manager/src/coa_serve/role_resolver.py
@@ -70,6 +70,12 @@ def resolve_profile(
 
     If no namespace is provided, only roles are resolved (no table/column merge).
     If RRM_TABLE_NAME is not configured, returns a minimal profile with just userId/groups.
+
+    Raises:
+        Exception: Propagates a grant-lookup failure. Resolution must not fall
+            back to a partial read — restrictions derived from a subset of the
+            grants are more permissive than the truth, so a transient DynamoDB
+            error would widen data access.
     """
     result = ResolvedProfile(user_id=user_id, groups=groups)
 
@@ -81,21 +87,35 @@ def resolve_profile(
     principal_keys = [f"User::{sanitize_principal_key(user_id)}"]
     principal_keys.extend(f"Group::{sanitize_principal_key(g)}" for g in groups)
 
-    # Collect all grant items for this principal
+    # Collect all grant items for this principal.
+    #
+    # query_all, not query: one query returns a single 1 MB page, and the grants
+    # on later pages carry tableAllowlist / columnDenylist. Dropping a restricted
+    # grant while an unrestricted one survives makes _merge_data_restrictions see
+    # no restrictions at all, so the SQL firewall stops enforcing them — a PII
+    # denylist silently disabled by a pagination boundary.
+    #
+    # A failure here must NOT degrade to a partial read for the same reason: the
+    # restrictions computed from a subset are more permissive than the truth. Fail
+    # the resolution instead and let the caller reject the request, matching the
+    # control-plane authorizer's fail-closed posture (it re-raises in the
+    # equivalent spot).
     all_items: list[dict[str, Any]] = []
     for pk in principal_keys:
         try:
-            query_result = dao.query(
-                QueryParams(
-                    key_condition="#pk = :pk",
-                    expression_values={":pk": pk},
-                    expression_names={"#pk": "principalKey"},
-                    index_name="PrincipalIndex",
+            all_items.extend(
+                dao.query_all(
+                    QueryParams(
+                        key_condition="#pk = :pk",
+                        expression_values={":pk": pk},
+                        expression_names={"#pk": "principalKey"},
+                        index_name="PrincipalIndex",
+                    )
                 )
             )
-            all_items.extend(query_result.items)
         except Exception:
             logger.exception("role_resolve_query_failed", principal_key=pk)
+            raise
 
     # Resolve roles from all items
     for item in all_items:

--- a/packages/context-manager/tests/unit/test_role_resolver.py
+++ b/packages/context-manager/tests/unit/test_role_resolver.py
@@ -27,18 +27,22 @@ def _result(items):
 
 
 def _mock_dao(items_by_pk):
-    """Return a DynamoDBDAO factory whose query() dispatches on principalKey.
+    """Return a DynamoDBDAO factory whose query dispatches on principalKey.
 
     ``items_by_pk`` maps the ``:pk`` expression value to the list of grant items
     returned for that principal.
+
+    Both ``query`` and ``query_all`` are stubbed: the resolver uses ``query_all``
+    (a single page would silently drop grants past 1 MB), and ``query_all``
+    returns a plain list rather than a ``PaginatedResult``.
     """
     dao = MagicMock()
 
-    def _query(params):
-        pk = params.expression_values[":pk"]
-        return _result(items_by_pk.get(pk, []))
+    def _items_for(params):
+        return items_by_pk.get(params.expression_values[":pk"], [])
 
-    dao.query.side_effect = _query
+    dao.query.side_effect = lambda params: _result(_items_for(params))
+    dao.query_all.side_effect = _items_for
     return dao
 
 
@@ -78,17 +82,25 @@ class TestResolveProfileRoles:
         assert "platform-viewer" in resolved.global_roles
         assert {"role": "namespace-maintainer", "resourceUID": _NS} in resolved.resource_roles
 
-    def test_query_exception_is_swallowed(self):
+    def test_query_exception_propagates(self):
+        """A grant-lookup failure must NOT degrade to a partial read.
+
+        Previously the exception was swallowed and resolution continued with
+        whatever had been collected. That is unsafe for this specific data:
+        restrictions computed from a subset of the grants are more PERMISSIVE
+        than the truth (see `_merge_data_restrictions` — a missing restricted
+        grant leaves `tableAllowlist`/`columnDenylist` unset, which the SQL
+        firewall reads as unrestricted). So a transient DynamoDB error widened
+        data access. Fail closed instead, matching the control-plane authorizer.
+        """
         dao = MagicMock()
-        dao.query.side_effect = RuntimeError("ddb down")
+        dao.query_all.side_effect = RuntimeError("ddb down")
         with (
             patch.object(role_resolver, "_RRM_TABLE", "rrm"),
             patch.object(role_resolver, "DynamoDBDAO", return_value=dao),
+            pytest.raises(RuntimeError, match="ddb down"),
         ):
-            resolved = resolve_profile("bob@x.com", [], namespace=_NS)
-        # No roles resolved, but no exception propagated (fail-closed posture).
-        assert resolved.global_roles == []
-        assert resolved.resource_roles == []
+            resolve_profile("bob@x.com", [], namespace=_NS)
 
     def test_no_namespace_skips_data_restriction_merge(self):
         items = {"User::alice@x.com": [{"role": "platform-admin", "resourceId": "GLOBAL"}]}
@@ -116,9 +128,25 @@ class TestResolveProfileRoles:
         ):
             resolve_profile("foo+123@x.com", ["group/eng"], namespace=_NS)
 
-        queried_pks = [call.args[0].expression_values[":pk"] for call in dao.query.call_args_list]
+        queried_pks = [call.args[0].expression_values[":pk"] for call in dao.query_all.call_args_list]
         assert "User::foo%2B123@x.com" in queried_pks
         assert "Group::group%2Feng" in queried_pks
+
+    def test_reads_every_page_of_grants(self):
+        """Grants must be read with query_all, not a single 1 MB query page.
+
+        A one-page read drops grants past the page boundary; when the dropped one
+        carries the restrictions, the SQL firewall stops enforcing them.
+        """
+        dao = _mock_dao({"User::u": [{"role": "data-analyst", "resourceId": _NS}]})
+        with (
+            patch.object(role_resolver, "_RRM_TABLE", "rrm"),
+            patch.object(role_resolver, "DynamoDBDAO", return_value=dao),
+        ):
+            resolve_profile("u", [], namespace=_NS)
+
+        dao.query_all.assert_called()
+        dao.query.assert_not_called()
 
 
 @pytest.mark.unit

--- a/packages/context-manager/tests/unit/test_role_resolver.py
+++ b/packages/context-manager/tests/unit/test_role_resolver.py
@@ -183,6 +183,51 @@ class TestMergeDataRestrictions:
         assert resolved.table_allowlist is None
         assert resolved.column_denylist is None
 
+    # ── GLOBAL grants must not relax namespace-scoped data restrictions ──────
+    # A platform grant (platform-admin / platform-viewer) is written with
+    # resourceId="GLOBAL" and carries no tableAllowlist/columnDenylist. It must
+    # NOT enter the per-namespace restriction merge: the "grant without a
+    # restriction means unrestricted" rule would otherwise erase the namespace
+    # grant's restrictions and the SQL firewall would stop enforcing them.
+
+    def test_global_grant_does_not_erase_column_denylist(self):
+        resolved = self._resolve(
+            [
+                {"role": "data-analyst", "resourceId": _NS, "columnDenylist": {"customers": ["ssn"]}},
+                {"role": "platform-viewer", "resourceId": "GLOBAL"},  # no restriction fields
+            ]
+        )
+        assert resolved.column_denylist == {"customers": ["ssn"]}
+
+    def test_global_grant_does_not_erase_table_allowlist(self):
+        resolved = self._resolve(
+            [
+                {"role": "data-analyst", "resourceId": _NS, "tableAllowlist": ["customers"]},
+                {"role": "platform-viewer", "resourceId": "GLOBAL"},
+            ]
+        )
+        assert resolved.table_allowlist == ["customers"]
+
+    def test_global_grant_does_not_erase_allowed_metrics(self):
+        resolved = self._resolve(
+            [
+                {"role": "data-analyst", "resourceId": _NS, "allowedMetrics": ["m1"]},
+                {"role": "platform-viewer", "resourceId": "GLOBAL"},
+            ]
+        )
+        assert resolved.allowed_metrics == ["m1"]
+
+    def test_global_grant_still_resolves_into_global_roles(self):
+        """Scoping the data merge must not affect Cedar-level platform privileges."""
+        resolved = self._resolve(
+            [
+                {"role": "data-analyst", "resourceId": _NS, "columnDenylist": {"customers": ["ssn"]}},
+                {"role": "platform-viewer", "resourceId": "GLOBAL"},
+            ]
+        )
+        assert resolved.global_roles == ["platform-viewer"]
+        assert resolved.column_denylist == {"customers": ["ssn"]}
+
 
 @pytest.mark.unit
 class TestInjectInto:

--- a/packages/control-plane/src/coa_control_plane/authorization/handler.py
+++ b/packages/control-plane/src/coa_control_plane/authorization/handler.py
@@ -267,7 +267,13 @@ def _resolve_roles(
 
     for pk in principal_keys:
         try:
-            result = dao.query(
+            # query_all, not query: a single query returns one 1 MB page, so a
+            # principal whose grants span more than that would have the roles on
+            # later pages silently dropped — yielding a 403 on a namespace the
+            # user holds a valid grant for. Page boundaries depend on internal
+            # item ordering, so which roles vanish can change between
+            # invocations, making it look intermittent and unreproducible.
+            items = dao.query_all(
                 QueryParams(
                     key_condition="#pk = :pk",
                     expression_values={":pk": pk},
@@ -278,7 +284,7 @@ def _resolve_roles(
         except Exception:
             logger.exception("Failed to query roles", principal_key=pk)
             raise
-        for item in result.items:
+        for item in items:
             role = item.get("role", "")
             resource_id = item.get("resourceId", "")
             if resource_id == "GLOBAL" and role:

--- a/packages/control-plane/src/coa_control_plane/grants/list_principal_grants_handler.py
+++ b/packages/control-plane/src/coa_control_plane/grants/list_principal_grants_handler.py
@@ -113,7 +113,10 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:  # noqa: ARG
         grants: list[dict[str, Any]] = []
 
         for pk in principal_keys:
-            result = mappings_dao.query(
+            # query_all, not query: a single query returns one 1 MB page, so a
+            # principal with many grants would see an arbitrary subset of their
+            # own permissions here — with no indication the list is incomplete.
+            items = mappings_dao.query_all(
                 QueryParams(
                     key_condition="#pk = :pk",
                     expression_values={":pk": pk},
@@ -121,7 +124,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:  # noqa: ARG
                     index_name="PrincipalIndex",
                 )
             )
-            for item in result.items:
+            for item in items:
                 summary = _to_grant_summary(item)
                 if summary["grantId"] not in seen_grant_ids:
                     seen_grant_ids.add(summary["grantId"])

--- a/packages/control-plane/src/coa_control_plane/namespace/list_handler.py
+++ b/packages/control-plane/src/coa_control_plane/namespace/list_handler.py
@@ -249,7 +249,10 @@ def resolve_accessible_namespace_ids(
 
     namespace_ids: set[str] = set()
     for pk in principal_keys:
-        result = mappings_dao.query(
+        # query_all, not query: one query returns a single 1 MB page, so a
+        # principal with many grants would have the namespaces on later pages
+        # omitted from every caller's view of "what this user can reach".
+        items = mappings_dao.query_all(
             QueryParams(
                 key_condition="#pk = :pk AND begins_with(#sk, :prefix)",
                 expression_values={":pk": pk, ":prefix": f"{ResourceType.NAMESPACE}::"},
@@ -257,7 +260,7 @@ def resolve_accessible_namespace_ids(
                 index_name="PrincipalIndex",
             )
         )
-        for item in result.items:
+        for item in items:
             namespace_ids.add(item["resourceId"])
 
     return namespace_ids

--- a/packages/control-plane/tests/unit/test_authorizer_handler.py
+++ b/packages/control-plane/tests/unit/test_authorizer_handler.py
@@ -168,9 +168,9 @@ class TestRolesCaching:
         from coa_control_plane.authorization.handler import _resolve_roles, _roles_cache
 
         mock_dao = MagicMock()
-        mock_dao.query.side_effect = [
-            MagicMock(items=[{"role": "ADMIN", "resourceId": "GLOBAL"}]),
-            MagicMock(items=[{"role": "data-steward", "resourceId": "ns-123"}]),
+        mock_dao.query_all.side_effect = [
+            [{"role": "ADMIN", "resourceId": "GLOBAL"}],
+            [{"role": "data-steward", "resourceId": "ns-123"}],
         ]
 
         global_roles, resource_roles = _resolve_roles("user@example.com", ["Admins"], mock_dao)
@@ -190,12 +190,12 @@ class TestRolesCaching:
         from coa_control_plane.authorization.handler import _resolve_roles
 
         mock_dao = MagicMock()
-        mock_dao.query.return_value = MagicMock(items=[])
+        mock_dao.query_all.return_value = []
 
         _resolve_roles("foo+123@amazon.com", [], mock_dao)
 
         # Verify the query was made with URL-encoded principal ID
-        query_call = mock_dao.query.call_args_list[0]
+        query_call = mock_dao.query_all.call_args_list[0]
         query_params = query_call[0][0]
         assert query_params.expression_values[":pk"] == "User::foo%2B123@amazon.com"
 
@@ -211,13 +211,13 @@ class TestRolesCaching:
 
         assert global_roles == ["VIEWER"]
         assert resource_roles == [{"role": "data-analyst", "resourceUID": "ns-456"}]
-        mock_dao.query.assert_not_called()
+        mock_dao.query_all.assert_not_called()
 
     def test_cache_key_groups_sorted(self, env_vars):
         from coa_control_plane.authorization.handler import _resolve_roles, _roles_cache
 
         mock_dao = MagicMock()
-        mock_dao.query.return_value = MagicMock(items=[])
+        mock_dao.query_all.return_value = []
 
         _resolve_roles("user@example.com", ["GroupB", "GroupA"], mock_dao)
 
@@ -234,15 +234,15 @@ class TestRolesCaching:
 
         mock_dao = MagicMock()
         # User query returns a role, group query returns nothing
-        mock_dao.query.side_effect = [
-            MagicMock(items=[{"role": "VIEWER", "resourceId": "GLOBAL"}]),
-            MagicMock(items=[]),
+        mock_dao.query_all.side_effect = [
+            [{"role": "VIEWER", "resourceId": "GLOBAL"}],
+            [],
         ]
 
         global_roles, resource_roles = _resolve_roles("user@example.com", ["GroupX"], mock_dao)
 
         # Should have queried DDB since cache was corrupt
-        assert mock_dao.query.called
+        assert mock_dao.query_all.called
         assert global_roles == ["VIEWER"]
         # Cache population disabled — entry should not exist after eviction
         assert cache_key not in _roles_cache

--- a/packages/control-plane/tests/unit/test_list_namespaces.py
+++ b/packages/control-plane/tests/unit/test_list_namespaces.py
@@ -90,11 +90,11 @@ class TestResolveAccessibleNamespaceIds:
         from coa_control_plane.namespace.list_handler import resolve_accessible_namespace_ids
 
         mappings_dao = MagicMock()
-        mappings_dao.query.return_value = PaginatedResult(items=[])
+        mappings_dao.query_all.return_value = []
 
         resolve_accessible_namespace_ids(mappings_dao, "foo+123@co.com", ["group/eng"])
 
-        queried_pks = [call.args[0].expression_values[":pk"] for call in mappings_dao.query.call_args_list]
+        queried_pks = [call.args[0].expression_values[":pk"] for call in mappings_dao.query_all.call_args_list]
         assert "User::foo%2B123@co.com" in queried_pks
         assert "Group::group%2Feng" in queried_pks
 
@@ -256,9 +256,9 @@ class TestScopedUser:
         mock_mappings_dao = MagicMock()
         mock_dao_cls.side_effect = [mock_ns_dao, mock_mappings_dao]
 
-        mock_mappings_dao.query.return_value = PaginatedResult(
-            items=[{"resourceType": "Namespace", "resourceId": "11111111-1111-1111-1111-111111111111", "role": "owner"}]
-        )
+        mock_mappings_dao.query_all.return_value = [
+            {"resourceType": "Namespace", "resourceId": "11111111-1111-1111-1111-111111111111", "role": "owner"}
+        ]
         mock_ns_dao.batch_get.return_value = [NS_ITEM]
 
         resp = handler(_event(user_id="alice@co.com"), None)
@@ -274,7 +274,7 @@ class TestScopedUser:
         mock_mappings_dao = MagicMock()
         mock_dao_cls.side_effect = [mock_ns_dao, mock_mappings_dao]
 
-        mock_mappings_dao.query.return_value = PaginatedResult(items=[])
+        mock_mappings_dao.query_all.return_value = []
 
         resp = handler(_event(user_id="nobody@co.com"), None)
 
@@ -288,17 +288,15 @@ class TestScopedUser:
         mock_mappings_dao = MagicMock()
         mock_dao_cls.side_effect = [mock_ns_dao, mock_mappings_dao]
 
-        mock_mappings_dao.query.side_effect = [
-            PaginatedResult(items=[]),
-            PaginatedResult(
-                items=[
-                    {
-                        "resourceType": "Namespace",
-                        "resourceId": "22222222-2222-2222-2222-222222222222",
-                        "role": "data-steward",
-                    }
-                ]
-            ),
+        mock_mappings_dao.query_all.side_effect = [
+            [],
+            [
+                {
+                    "resourceType": "Namespace",
+                    "resourceId": "22222222-2222-2222-2222-222222222222",
+                    "role": "data-steward",
+                }
+            ],
         ]
         mock_ns_dao.batch_get.return_value = [NS_ITEM_2]
 
@@ -315,21 +313,15 @@ class TestScopedUser:
         mock_mappings_dao = MagicMock()
         mock_dao_cls.side_effect = [mock_ns_dao, mock_mappings_dao]
 
-        mock_mappings_dao.query.side_effect = [
-            PaginatedResult(
-                items=[
-                    {"resourceType": "Namespace", "resourceId": "11111111-1111-1111-1111-111111111111", "role": "owner"}
-                ]
-            ),
-            PaginatedResult(
-                items=[
-                    {
-                        "resourceType": "Namespace",
-                        "resourceId": "11111111-1111-1111-1111-111111111111",
-                        "role": "data-steward",
-                    }
-                ]
-            ),
+        mock_mappings_dao.query_all.side_effect = [
+            [{"resourceType": "Namespace", "resourceId": "11111111-1111-1111-1111-111111111111", "role": "owner"}],
+            [
+                {
+                    "resourceType": "Namespace",
+                    "resourceId": "11111111-1111-1111-1111-111111111111",
+                    "role": "data-steward",
+                }
+            ],
         ]
         mock_ns_dao.batch_get.return_value = [NS_ITEM]
 
@@ -349,13 +341,11 @@ class TestScopedUser:
         mock_dao_cls.side_effect = [mock_ns_dao, mock_mappings_dao]
 
         # User has access to 3 namespaces
-        mock_mappings_dao.query.return_value = PaginatedResult(
-            items=[
-                {"resourceType": "Namespace", "resourceId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "role": "owner"},
-                {"resourceType": "Namespace", "resourceId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "role": "owner"},
-                {"resourceType": "Namespace", "resourceId": "cccccccc-cccc-cccc-cccc-cccccccccccc", "role": "owner"},
-            ]
-        )
+        mock_mappings_dao.query_all.return_value = [
+            {"resourceType": "Namespace", "resourceId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "role": "owner"},
+            {"resourceType": "Namespace", "resourceId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "role": "owner"},
+            {"resourceType": "Namespace", "resourceId": "cccccccc-cccc-cccc-cccc-cccccccccccc", "role": "owner"},
+        ]
         mock_ns_dao.batch_get.return_value = [
             {
                 **NS_ITEM,
@@ -387,13 +377,11 @@ class TestScopedUser:
 
         # Request page 2 using the token
         mock_dao_cls.side_effect = [mock_ns_dao, mock_mappings_dao]
-        mock_mappings_dao.query.return_value = PaginatedResult(
-            items=[
-                {"resourceType": "Namespace", "resourceId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "role": "owner"},
-                {"resourceType": "Namespace", "resourceId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "role": "owner"},
-                {"resourceType": "Namespace", "resourceId": "cccccccc-cccc-cccc-cccc-cccccccccccc", "role": "owner"},
-            ]
-        )
+        mock_mappings_dao.query_all.return_value = [
+            {"resourceType": "Namespace", "resourceId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", "role": "owner"},
+            {"resourceType": "Namespace", "resourceId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", "role": "owner"},
+            {"resourceType": "Namespace", "resourceId": "cccccccc-cccc-cccc-cccc-cccccccccccc", "role": "owner"},
+        ]
         resp2 = handler(
             _event(user_id="alice@co.com", query_params={"maxResults": "2", "nextToken": body["nextToken"]}),
             None,
@@ -410,14 +398,14 @@ class TestScopedUser:
         mock_mappings_dao = MagicMock()
         mock_dao_cls.side_effect = [mock_ns_dao, mock_mappings_dao]
 
-        mock_mappings_dao.query.return_value = PaginatedResult(
-            items=[{"resourceType": "Namespace", "resourceId": "11111111-1111-1111-1111-111111111111", "role": "owner"}]
-        )
+        mock_mappings_dao.query_all.return_value = [
+            {"resourceType": "Namespace", "resourceId": "11111111-1111-1111-1111-111111111111", "role": "owner"}
+        ]
         mock_ns_dao.batch_get.return_value = [NS_ITEM]
 
         handler(_event(user_id="alice@co.com"), None)
 
-        call_args = mock_mappings_dao.query.call_args[0][0]
+        call_args = mock_mappings_dao.query_all.call_args[0][0]
         assert "begins_with" in call_args.key_condition
         assert call_args.expression_values[":prefix"] == "Namespace::"
 

--- a/packages/control-plane/tests/unit/test_list_principal_grants.py
+++ b/packages/control-plane/tests/unit/test_list_principal_grants.py
@@ -10,7 +10,6 @@ import os
 from unittest.mock import MagicMock, patch
 
 import pytest
-from coa_common.dao import PaginatedResult
 
 os.environ.update(
     {
@@ -63,21 +62,18 @@ class TestListPrincipalGrants:
     def test_lists_grants_for_self(self, mock_dao_cls):
         mock_dao = MagicMock()
         mock_dao_cls.return_value = mock_dao
-        mock_dao.query.return_value = PaginatedResult(
-            items=[
-                {
-                    "PK": f"Namespace::{VALID_NS_ID}#User::alice@company.com",
-                    "SK": "ROLE#analyst",
-                    "resourceId": VALID_NS_ID,
-                    "principalType": "User",
-                    "principalId": "alice@company.com",
-                    "role": "analyst",
-                    "grantedBy": "bob@company.com",
-                    "grantedAt": "2026-04-09T10:00:00Z",
-                },
-            ],
-            last_evaluated_key=None,
-        )
+        mock_dao.query_all.return_value = [
+            {
+                "PK": f"Namespace::{VALID_NS_ID}#User::alice@company.com",
+                "SK": "ROLE#analyst",
+                "resourceId": VALID_NS_ID,
+                "principalType": "User",
+                "principalId": "alice@company.com",
+                "role": "analyst",
+                "grantedBy": "bob@company.com",
+                "grantedAt": "2026-04-09T10:00:00Z",
+            },
+        ]
 
         resp = handler(_event_me(), None)
         assert resp["statusCode"] == 200
@@ -86,7 +82,7 @@ class TestListPrincipalGrants:
         assert body["grants"][0]["role"] == "analyst"
 
         # Verify PrincipalIndex GSI was used with sanitized email
-        query_call = mock_dao.query.call_args[0][0]
+        query_call = mock_dao.query_all.call_args[0][0]
         assert query_call.index_name == "PrincipalIndex"
         assert ":pk" in query_call.expression_values
         assert query_call.expression_values[":pk"] == "User::alice@company.com"
@@ -95,14 +91,14 @@ class TestListPrincipalGrants:
     def test_queries_user_and_groups(self, mock_dao_cls):
         mock_dao = MagicMock()
         mock_dao_cls.return_value = mock_dao
-        mock_dao.query.return_value = PaginatedResult(items=[], last_evaluated_key=None)
+        mock_dao.query_all.return_value = []
 
         resp = handler(_event_me("alice@co.com", "admins,viewers"), None)
         assert resp["statusCode"] == 200
 
         # Should query 3 times: User + 2 groups
-        assert mock_dao.query.call_count == 3
-        keys_queried = [call[0][0].expression_values[":pk"] for call in mock_dao.query.call_args_list]
+        assert mock_dao.query_all.call_count == 3
+        keys_queried = [call[0][0].expression_values[":pk"] for call in mock_dao.query_all.call_args_list]
         assert "User::alice@co.com" in keys_queried
         assert "Group::admins" in keys_queried
         assert "Group::viewers" in keys_queried
@@ -122,7 +118,7 @@ class TestListPrincipalGrants:
             "grantedBy": "admin@co.com",
             "grantedAt": "2026-05-01T00:00:00Z",
         }
-        mock_dao.query.return_value = PaginatedResult(items=[grant_item], last_evaluated_key=None)
+        mock_dao.query_all.return_value = [grant_item]
 
         resp = handler(_event_me("alice@co.com", "team"), None)
         body = json.loads(resp["body"])
@@ -133,46 +129,46 @@ class TestListPrincipalGrants:
     def test_normalizes_email_to_lowercase(self, mock_dao_cls):
         mock_dao = MagicMock()
         mock_dao_cls.return_value = mock_dao
-        mock_dao.query.return_value = PaginatedResult(items=[], last_evaluated_key=None)
+        mock_dao.query_all.return_value = []
 
         resp = handler(_event_me("Alice@Company.COM"), None)
         assert resp["statusCode"] == 200
 
-        key = mock_dao.query.call_args[0][0].expression_values[":pk"]
+        key = mock_dao.query_all.call_args[0][0].expression_values[":pk"]
         assert key == "User::alice@company.com"
 
     @patch("coa_control_plane.grants.list_principal_grants_handler.DynamoDBDAO")
     def test_limits_groups_to_max(self, mock_dao_cls):
         mock_dao = MagicMock()
         mock_dao_cls.return_value = mock_dao
-        mock_dao.query.return_value = PaginatedResult(items=[], last_evaluated_key=None)
+        mock_dao.query_all.return_value = []
 
         many_groups = ",".join(f"group{i}" for i in range(20))
         resp = handler(_event_me("a@b.com", many_groups), None)
         assert resp["statusCode"] == 200
         # 1 user + max 10 groups = 11 queries
-        assert mock_dao.query.call_count == 11
+        assert mock_dao.query_all.call_count == 11
 
     @patch("coa_control_plane.grants.list_principal_grants_handler.DynamoDBDAO")
     def test_skips_invalid_group_names(self, mock_dao_cls):
         mock_dao = MagicMock()
         mock_dao_cls.return_value = mock_dao
-        mock_dao.query.return_value = PaginatedResult(items=[], last_evaluated_key=None)
+        mock_dao.query_all.return_value = []
 
         resp = handler(_event_me("a@b.com", "valid-group,bad::group,ok_group"), None)
         assert resp["statusCode"] == 200
         # 1 user + 2 valid groups (bad::group skipped)
-        assert mock_dao.query.call_count == 3
+        assert mock_dao.query_all.call_count == 3
 
     @patch("coa_control_plane.grants.list_principal_grants_handler.DynamoDBDAO")
     def test_fallback_to_claims_email(self, mock_dao_cls):
         mock_dao = MagicMock()
         mock_dao_cls.return_value = mock_dao
-        mock_dao.query.return_value = PaginatedResult(items=[], last_evaluated_key=None)
+        mock_dao.query_all.return_value = []
 
         resp = handler(_event_me_claims("bob@co.com", "devs"), None)
         assert resp["statusCode"] == 200
-        key = mock_dao.query.call_args_list[0][0][0].expression_values[":pk"]
+        key = mock_dao.query_all.call_args_list[0][0][0].expression_values[":pk"]
         assert key == "User::bob@co.com"
 
     def test_rejects_non_me_principal(self):
@@ -207,7 +203,7 @@ class TestListPrincipalGrants:
     def test_dynamo_error_returns_500(self, mock_dao_cls):
         mock_dao = MagicMock()
         mock_dao_cls.return_value = mock_dao
-        mock_dao.query.side_effect = Exception("DynamoDB throttled")
+        mock_dao.query_all.side_effect = Exception("DynamoDB throttled")
 
         resp = handler(_event_me(), None)
         assert resp["statusCode"] == 500
@@ -238,7 +234,7 @@ class TestListPrincipalGrantsToGrantSummary:
             "columnDenylist": {"customers": ["ssn", "dob"]},
             "allowedMetrics": ["revenue", "order_count"],
         }
-        mock_dao.query.return_value = PaginatedResult(items=[item], last_evaluated_key=None)
+        mock_dao.query_all.return_value = [item]
         resp = handler(_event_me(), None)
         body = json.loads(resp["body"])
         grant = body["grants"][0]
@@ -251,7 +247,7 @@ class TestListPrincipalGrantsToGrantSummary:
     def test_overrides_absent_are_omitted(self, mock_dao_cls):
         mock_dao = MagicMock()
         mock_dao_cls.return_value = mock_dao
-        mock_dao.query.return_value = PaginatedResult(items=[self.BASE_ITEM], last_evaluated_key=None)
+        mock_dao.query_all.return_value = [self.BASE_ITEM]
         resp = handler(_event_me(), None)
         body = json.loads(resp["body"])
         grant = body["grants"][0]
@@ -270,7 +266,7 @@ class TestListPrincipalGrantsToGrantSummary:
             "columnDenylist": {},
             "allowedMetrics": [],
         }
-        mock_dao.query.return_value = PaginatedResult(items=[item], last_evaluated_key=None)
+        mock_dao.query_all.return_value = [item]
         resp = handler(_event_me(), None)
         body = json.loads(resp["body"])
         grant = body["grants"][0]
@@ -283,7 +279,7 @@ class TestListPrincipalGrantsToGrantSummary:
         mock_dao = MagicMock()
         mock_dao_cls.return_value = mock_dao
         item = {**self.BASE_ITEM, "columnDenylist": {"customers": ["ssn"]}}
-        mock_dao.query.return_value = PaginatedResult(items=[item], last_evaluated_key=None)
+        mock_dao.query_all.return_value = [item]
         resp = handler(_event_me(), None)
         body = json.loads(resp["body"])
         grant = body["grants"][0]

--- a/packages/mcp-server/src/coa_mcp/auth/grant_resolver.py
+++ b/packages/mcp-server/src/coa_mcp/auth/grant_resolver.py
@@ -192,25 +192,28 @@ async def resolve_grant(
             namespace=namespace_id,
         )
     except Exception as e:
-        # If role resolution fails but user is admin, allow with empty restrictions
-        if "Admin" in caller.roles or "admin" in caller.roles:
-            logger.warning(
-                "grant_resolution_failed_admin_fallback",
-                user_id=caller.user_id,
-                namespace=namespace_id,
-                error=str(e),
-            )
-            return ResolvedProfile(
-                namespace=namespace_id,
-                user_id=caller.user_id,
-                global_roles=["platform-admin"],
-                resource_roles=[{"role": "namespace-owner", "resourceUID": namespace_id}],
-            )
-
+        # Fail closed for EVERY caller, admins included.
+        #
+        # There used to be an admin fallback here that returned platform-admin +
+        # namespace-owner and returned EARLY — before the Cedar evaluation below,
+        # despite that block's comment claiming it is never bypassed. It granted
+        # those roles off nothing but an "admin" entry in the caller's IdP groups,
+        # with no policy check and no data restrictions.
+        #
+        # It was near-unreachable while resolve_profile swallowed its own query
+        # errors, but that method now propagates them (a partial grant read is more
+        # permissive than the truth, so degrading there widened data access). A
+        # DynamoDB throttle would therefore have escalated any admin-group caller.
+        #
+        # A failed grant read means we do not know what this caller may do, which is
+        # never a reason to assume the most privileged answer. Denying turns a
+        # transient backend error into a retryable failure instead of a silent
+        # privilege escalation.
         logger.error(
             "grant_resolution_failed",
             user_id=caller.user_id,
             namespace=namespace_id,
+            is_admin_group_member=any(r.lower() == "admin" for r in caller.roles),
             error=str(e),
         )
         raise GrantResolutionError(f"Failed to resolve grant for user '{caller.user_id}': {e}") from e

--- a/packages/mcp-server/tests/unit/test_grant_resolver.py
+++ b/packages/mcp-server/tests/unit/test_grant_resolver.py
@@ -236,29 +236,46 @@ class TestCedarEvaluation:
 class TestRoleResolutionFailure:
     """Behavior when the shared role_resolver raises."""
 
+    # An admin caller used to get platform-admin + namespace-owner here, returned
+    # EARLY — before the Cedar evaluation — off nothing but an "admin" entry in
+    # their IdP groups. A failed grant read means we do not know what the caller
+    # may do, which is never a reason to assume the most privileged answer. The
+    # path also became reachable once resolve_profile stopped swallowing its query
+    # errors, so a DynamoDB throttle would have escalated any admin-group caller.
+
     @pytest.mark.asyncio
     @patch("coa_serve.role_resolver.resolve_profile")
-    async def test_admin_role_falls_back_to_owner_profile(self, mock_resolve):
-        """When role resolution fails but caller is admin, allow with owner profile."""
+    async def test_admin_role_resolution_failure_raises(self, mock_resolve):
+        """Admins fail closed too — no privilege escalation on a backend error."""
         mock_resolve.side_effect = RuntimeError("RRM table unavailable")
         caller = _make_caller(user_id="root", namespaces=["sales"], roles=["Admin"])
 
-        profile = await resolve_grant(caller, "sales")
-
-        assert profile.namespace == "sales"
-        assert profile.user_id == "root"
-        assert profile.global_roles == ["platform-admin"]
-        assert profile.resource_roles == [{"role": "namespace-owner", "resourceUID": "sales"}]
+        with pytest.raises(GrantResolutionError, match="Failed to resolve grant"):
+            await resolve_grant(caller, "sales")
 
     @pytest.mark.asyncio
     @patch("coa_serve.role_resolver.resolve_profile")
-    async def test_lowercase_admin_role_falls_back(self, mock_resolve):
+    async def test_lowercase_admin_role_also_fails_closed(self, mock_resolve):
         mock_resolve.side_effect = RuntimeError("boom")
         caller = _make_caller(user_id="root", namespaces=["sales"], roles=["admin"])
 
-        profile = await resolve_grant(caller, "sales")
+        with pytest.raises(GrantResolutionError, match="Failed to resolve grant"):
+            await resolve_grant(caller, "sales")
 
-        assert profile.global_roles == ["platform-admin"]
+    @pytest.mark.asyncio
+    @patch("coa_serve.role_resolver.resolve_profile")
+    async def test_failure_never_returns_a_profile_that_skips_cedar(self, mock_resolve):
+        """The escalation was worse than its roles: it returned before Cedar ran."""
+        mock_resolve.side_effect = RuntimeError("throttled")
+        caller = _make_caller(user_id="root", namespaces=["sales"], roles=["Admin"])
+
+        with (
+            patch("coa_mcp.auth.grant_resolver._evaluate_cedar") as mock_cedar,
+            pytest.raises(GrantResolutionError),
+        ):
+            await resolve_grant(caller, "sales")
+
+        mock_cedar.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("coa_serve.role_resolver.resolve_profile")


### PR DESCRIPTION
Split from #19 (11/11). Fixes #17, fixes #18.

These two stay grouped because they share `role_resolver.py`. Both narrow authorization:

- #17 — GLOBAL grants (e.g. platform-viewer) no longer dissolve namespace-scoped data restrictions: the data-restriction merge is scoped to the target namespace, so `columnDenylist`/`tableAllowlist` keep enforcing PII limits in the SQL firewall.
- #18 — role resolution reads every page of PrincipalIndex instead of only the first 1 MB, eliminating intermittent 403s and silently unenforced restrictions. Grant-resolution failure now fails closed for admins too.

File-disjoint from every other PR in the split.
