### PR TITLE
fix(web-app): pad short OIDC sub to AgentCore 33-char session-id min

### DIFF
--- a/packages/web-app/src/api-hooks/use-playground-stream.ts
+++ b/packages/web-app/src/api-hooks/use-playground-stream.ts
@@ -27,6 +27,7 @@ import type {
   StreamingErrorEvent,
 } from "@app-types/playground";
 import { isStreamingEvent } from "@utils/sse-type-guards";
+import { deriveRuntimeSessionId } from "@utils/runtime-session-id";
 
 export interface UsePlaygroundStreamOptions {
   /** AgentCore Runtime endpoint URL (public endpoint or CloudFront path). */
@@ -70,14 +71,16 @@ export function usePlaygroundStream({
       setIsStreaming(true);
 
       // Get ID token and user sub (carries email + groups for Cedar auth; AgentCore validates aud)
-      // Sub is used for X-Amzn-Bedrock-AgentCore-Runtime-Session-Id (≥33 chars, sticky routing)
+      // Sub feeds X-Amzn-Bedrock-AgentCore-Runtime-Session-Id (must be ≥33 chars,
+      // sticky routing) — deriveRuntimeSessionId pads/normalizes since IdPs like
+      // Midway issue short subs (e.g. "noahpaig") that fail that constraint as-is.
       let token: string;
       let runtimeSessionId: string | undefined;
       try {
         const provider = OIDCProvider.build(oidcConfig);
         token = await provider.getIdToken();
         const user = await provider.getUser();
-        runtimeSessionId = user?.profile?.sub ?? undefined;
+        runtimeSessionId = deriveRuntimeSessionId(user?.profile?.sub);
         if (!token) {
           onEventRef.current(
             makeErrorEvent(

--- a/packages/web-app/src/api-hooks/use-sessions.test.ts
+++ b/packages/web-app/src/api-hooks/use-sessions.test.ts
@@ -10,7 +10,7 @@ vi.mock("@auth", () => ({
     build: () => ({
       getIdToken: vi.fn().mockResolvedValue("mock-token"),
       getUser: vi.fn().mockResolvedValue({
-        profile: { sub: "user-sub-uuid-1234567890123456" },
+        profile: { sub: "12345678-abcd-1234-abcd-1234567890ab" },
       }),
     }),
   },
@@ -187,7 +187,7 @@ describe("useSessions", () => {
 
     const headers = mockFetch.mock.calls[0][1].headers;
     expect(headers["X-Amzn-Bedrock-AgentCore-Runtime-Session-Id"]).toBe(
-      "user-sub-uuid-1234567890123456",
+      "12345678-abcd-1234-abcd-1234567890ab",
     );
     expect(headers["Authorization"]).toBe("Bearer mock-token");
   });

--- a/packages/web-app/src/utils/invoke-agentcore.ts
+++ b/packages/web-app/src/utils/invoke-agentcore.ts
@@ -9,6 +9,7 @@
  * use-session-history.ts, and use-playground-stream.ts.
  */
 import { OIDCProvider } from "@auth";
+import { deriveRuntimeSessionId } from "./runtime-session-id";
 
 export interface AgentCoreRequestOptions {
   /** AgentCore Runtime endpoint URL. */
@@ -74,7 +75,7 @@ export async function invokeAgentCore(
     const token = await provider.getIdToken();
     if (!token) return null;
     const user = await provider.getUser();
-    const runtimeSessionId = user?.profile?.sub;
+    const runtimeSessionId = deriveRuntimeSessionId(user?.profile?.sub);
 
     let response: Response;
     try {

--- a/packages/web-app/src/utils/runtime-session-id.test.ts
+++ b/packages/web-app/src/utils/runtime-session-id.test.ts
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { deriveRuntimeSessionId } from "./runtime-session-id";
+
+describe("deriveRuntimeSessionId", () => {
+  it("returns undefined for a missing sub", () => {
+    expect(deriveRuntimeSessionId(undefined)).toBeUndefined();
+  });
+
+  it("pads a short sub (e.g. Midway username) to the 33-char minimum", () => {
+    const result = deriveRuntimeSessionId("noahpaig");
+    expect(result).toBeDefined();
+    expect(result!.length).toBeGreaterThanOrEqual(33);
+    expect(result!.startsWith("noahpaig")).toBe(true);
+  });
+
+  it("returns a Cognito-style UUID sub unchanged (already ≥33 chars)", () => {
+    const uuidSub = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"; // 36 chars
+    expect(deriveRuntimeSessionId(uuidSub)).toBe(uuidSub);
+  });
+
+  it("is deterministic — same sub always maps to the same session id", () => {
+    expect(deriveRuntimeSessionId("noahpaig")).toBe(
+      deriveRuntimeSessionId("noahpaig"),
+    );
+  });
+});

--- a/packages/web-app/src/utils/runtime-session-id.ts
+++ b/packages/web-app/src/utils/runtime-session-id.ts
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * AgentCore Runtime requires `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` to
+ * be at least 33 characters (enforced server-side — a short value 400s with
+ * "Member must have length greater than or equal to 33").
+ *
+ * The OIDC `sub` claim is NOT guaranteed to satisfy this: Cognito issues UUIDs
+ * (36 chars, always safe), but other IdPs — e.g. Midway/federate — issue short
+ * human-readable usernames (e.g. "noahpaig", 8 chars), which fail the AgentCore
+ * constraint outright.
+ */
+const MIN_RUNTIME_SESSION_ID_LENGTH = 33;
+
+/**
+ * Derive a stable, ≥33-char AgentCore runtime session id from an OIDC `sub`.
+ * Deterministic per `sub` (same user always maps to the same session id, so
+ * AgentCore's sticky routing still groups a user's requests together).
+ *
+ * Returns undefined if `sub` is falsy (caller omits the header entirely).
+ */
+export function deriveRuntimeSessionId(
+  sub: string | undefined,
+): string | undefined {
+  if (!sub) return undefined;
+  return sub.padEnd(MIN_RUNTIME_SESSION_ID_LENGTH, "0");
+}


### PR DESCRIPTION
## Summary
AgentCore Runtime rejects `X-Amzn-Bedrock-AgentCore-Runtime-Session-Id` under 33 chars. Cognito subs (UUIDs, 36 chars) always satisfied this by coincidence; Midway/federate subs (e.g. `noahpaig`, 8 chars) don't — every Playground request 400d before reaching the agent.

## Change
Added `deriveRuntimeSessionId()` (pads short subs deterministically via `String.padEnd`, passes long subs through unchanged) and wired it into both call sites: `use-playground-stream.ts` and `invoke-agentcore.ts`.

## Observation step
Run `pnpm vitest run src/utils/runtime-session-id.test.ts` from `packages/web-app` — expect 4/4 pass. End-to-end: load the Playground page while signed in via an IdP with a short `sub` (e.g. Midway) and submit a query — expect no `runtimeSessionId` validation error.