### PR TITLE
fix(infra): supply an existing LF admin role to unblock brownfield bootstrap

### DIFF
--- a/external-docs/content/getting-started.md
+++ b/external-docs/content/getting-started.md
@@ -63,11 +63,36 @@ All stacks use context-driven configuration via `CoaStack` base class:
 | `project_tag`              | `semantic-context` | AWS `Project` tag value                                        |
 | `vpc_id`                   | (none)             | Import an existing VPC instead of creating one                 |
 | `aoss_max_ocu`             | `96`               | Max OCU capacity for OpenSearch Serverless (indexing + search) |
-| `aoss_min_ocu`             | `0`                | Min OCU capacity for OpenSearch Serverless (indexing + search) |
+| `aoss_min_ocu`             | `2`                | Min OCU capacity for OpenSearch Serverless (indexing + search). Set to `0` for scale-to-zero — see below |
+| `lf_admin_role_arn`        | (none)             | Existing Lake Formation data-lake admin role to run the LF-admin custom resource as. Required on accounts that already have LF admins |
 | `api_throttle_rate_limit`  | `50`               | API Gateway stage requests-per-second rate limit               |
 | `api_throttle_burst_limit` | `100`              | API Gateway stage burst capacity                               |
 
 Resource naming follows `{prefix}-{env}-{name}` (e.g. `coa-dev-neptune`).
+
+#### OpenSearch Serverless capacity and scale-to-zero
+
+The vector collection is a **NextGen** collection (`generation: "NEXTGEN"` on the
+collection group), not Classic. NextGen supports scaling compute to zero when
+idle, which removes the always-on OCU cost floor, but COA ships a minimum of
+**2 OCU** rather than 0 so that a default deployment does not pay cold-start
+latency on its first query after an idle period.
+
+To opt into scale-to-zero:
+
+```bash
+cdk deploy -c aoss_min_ocu=0
+```
+
+Valid `aoss_min_ocu` values are `0`, `2`, `4`, `8`, `16`, or multiples of 16.
+Leave standby replicas alone — AWS rejects `standbyReplicas: DISABLED` for
+NextGen, which manages replicas internally.
+
+The tradeoff at minimum 0: compute scales down after a period of inactivity and
+takes roughly ten seconds to return, and at very low OCU the NextGen circuit
+breaker sheds load with HTTP 429s under an ingestion burst. That is usually the
+right trade for dev and sandbox environments, and usually the wrong one for an
+environment serving interactive queries or running large scans.
 
 #### First-time deployment
 
@@ -84,13 +109,54 @@ Lake Formation **data-lake admin**. The `LakeFormationAdmin` custom resource
 registers it automatically and non-destructively (it appends to the existing
 admin list rather than overwriting it).
 
-There is a one-time bootstrap caveat: `PutDataLakeSettings` can only be called by
-an existing LF admin once an account already has any admins. So:
+There is a one-time bootstrap caveat: `PutDataLakeSettings` may only be called by
+an existing LF admin once an account already has any admins, and the caller is the
+custom resource's own Lambda role.
 
 - **Greenfield accounts** (no LF admins yet) self-bootstrap — no action needed.
-- **Accounts that already have LF admins:** register the custom resource's Lambda
-  role as an LF admin once, out-of-band, **before the first deploy**. Otherwise
-  JDBC scans fail at `CreateCatalog` with an access-denied error.
+- **Accounts that already have LF admins:** supply a role you already own and have
+  already registered as an LF admin, via the `lf_admin_role_arn` context variable.
+  The custom resource runs as that role, so the call is authorized on the first
+  deploy.
+
+  ```bash
+  cdk deploy coa-dev-sources -c lf_admin_role_arn=arn:aws:iam::<account>:role/<your-lf-admin>
+  ```
+
+  The role must be assumable by `lambda.amazonaws.com`. COA attaches the
+  permissions it needs (LF settings read/write, one SSM parameter read, Lambda
+  logging) to it; it does not need them beforehand.
+
+Without `lf_admin_role_arn` on an account that already has admins, the
+`coa-<env>-sources` **stack fails at deploy time** on the `LakeFormationAdmin`
+custom resource. It does not fail later at scan time, and registering the
+federation provisioner role by hand does not help — that is the role being
+*registered*, not the one making the call.
+
+Recovering without `lf_admin_role_arn` is possible but awkward, because the
+auto-created caller role is deleted by the rollback and re-created under a new
+auto-generated name on retry, invalidating any registration made against the old
+ARN. It requires `cdk deploy --no-rollback` so the role survives with a stable
+ARN, registering it out-of-band, then deploying again. Prefer
+`lf_admin_role_arn`.
+
+#### What COA changes about your Lake Formation posture
+
+Worth knowing before the first deploy, on any account:
+
+- Your existing data-lake admins are **preserved**. The custom resource reads the
+  current settings, appends one principal, and writes them back; it never
+  overwrites the admin list. Other settings, including the
+  `IAM_ALLOWED_PRINCIPALS` defaults that make LF defer to IAM, are round-tripped
+  untouched — deploying COA does not flip an account into strict LF mode.
+- On a **greenfield** account, the first deploy takes `DataLakeAdmins` from empty
+  to non-empty, and LF then begins enforcing admin-only access to settings. Any
+  principal of yours that previously managed LF settings through IAM permission
+  alone — a console role, your own IaC — stops being able to. Add it as an admin
+  alongside COA's (supplying `lf_admin_role_arn` is the easiest way to do both in
+  one up-front registration).
+- `cdk destroy` deregisters the principal COA registered. If you also register it
+  by hand, expect teardown to remove it.
 
 See `infra/README.md` (Lake Formation bootstrap) for the exact registration
 commands and troubleshooting.

--- a/infra/README.md
+++ b/infra/README.md
@@ -426,18 +426,48 @@ Per-environment shared resources (Structured Stack): a single Glue Data Catalog 
 
 Provisioning runs in a **dedicated `{prefix}sources-federation-provisioner` Lambda**, invoked as its own JDBC-only step in the scan pipeline (after discovery, before enrichment). It is intentionally separate from the discovery connector so the broad Lake Formation privilege stays isolated to a single-purpose role. The step is **fatal**: if provisioning fails, the pipeline's Catch marks the scan `FAILED` and the source `SCAN_FAILED`, since a source that isn't queryable is not a successful scan.
 
-**Required bootstrap (LF data-lake admin):** creating a federated catalog from a per-source connection requires `DATA_LOCATION_ACCESS` on that connection, which only a Lake Formation **data-lake admin** can grant (a non-admin cannot self-grant, and hybrid-access mode does not bypass it). The federation provisioner role must therefore be registered as an LF data-lake admin. This is now **automated** by the `LakeFormationAdmin` custom resource (`infra/lib/constructs/lakeformation-admin.ts`), which registers the role non-destructively (read `DataLakeAdmins` → append → write, preserving existing admins). The manual step below is only needed as a one-time **bootstrap for accounts that already have LF admins**: `PutDataLakeSettings` can only be called by an existing admin, so the custom resource's own Lambda role must be made an LF admin once, out-of-band, before the first deploy. Greenfield accounts (no admins yet) self-bootstrap. See `docs/getting-started.md` (Lake Formation bootstrap).
+**Required bootstrap (LF data-lake admin):** creating a federated catalog from a per-source connection requires `DATA_LOCATION_ACCESS` on that connection, which only a Lake Formation **data-lake admin** can grant (a non-admin cannot self-grant, and hybrid-access mode does not bypass it). The federation provisioner role must therefore be registered as an LF data-lake admin. This is **automated** by the `LakeFormationAdmin` custom resource (`infra/lib/constructs/lakeformation-admin.ts`), which registers the role non-destructively (read `DataLakeAdmins` → append → write, preserving existing admins).
 
-**Troubleshooting — `CreateCatalog` fails with `Insufficient Lake Formation permission(s): Required Create Catalog on Catalog`:** the bootstrap above has not been applied in the target account. This is a Lake Formation authorization error, **not** IAM — adding `glue:CreateCatalog` / `lakeformation:*` to the role's IAM policy will not fix it. Register the provisioner role as an LF data-lake admin:
+There are two distinct roles here, and conflating them is the usual source of confusion:
+
+| Role | Purpose | Where it comes from |
+| --- | --- | --- |
+| Federation provisioner (`{prefix}sources-federation-provisioner`) | The **target** — gets registered as an LF admin | Created by this stack; ARN published to `/{prefix}/sources/federation-provisioner-role-arn` |
+| LF-admin custom resource's onEvent Lambda role | The **caller** — invokes `PutDataLakeSettings` | Auto-created by this stack, or supplied via `lf_admin_role_arn` |
+
+`PutDataLakeSettings` may only be called by an existing data-lake admin once an account has any admins, and the caller is the second role. So:
+
+- **Greenfield accounts** (zero LF admins): nothing to do. LF has no admin to enforce, so the auto-created caller role self-bootstraps.
+- **Accounts that already have LF admins:** deploy with `lf_admin_role_arn` set to a role you already own and have already registered as an LF admin:
+
+  ```bash
+  cdk deploy coa-dev-sources -c lf_admin_role_arn=arn:aws:iam::<account>:role/<your-lf-admin>
+  ```
+
+  The role must be assumable by `lambda.amazonaws.com`; the construct attaches the IAM permissions the handler needs (LF settings read/write, one SSM parameter read, Lambda logging), so it does not need them beforehand.
+
+Registering the *provisioner* role by hand does **not** substitute for this — that is the role being registered, not the one making the call, and the custom resource re-issues `PutDataLakeSettings` on every deploy even when the target is already in the admin list.
+
+**Why there is no "register the caller role before the first deploy" option.** Earlier revisions of this doc said exactly that. It cannot work: without `lf_admin_role_arn` the caller role is created by the very deploy that needs it, and it is auto-named, so there is no ARN to register beforehand. Worse, the failed deploy's rollback deletes it, a first-ever create lands in `ROLLBACK_COMPLETE` (not updatable — it must be deleted and re-created), and the replacement gets a fresh random name suffix, invalidating any registration made against the old ARN.
+
+**Troubleshooting — the `coa-<env>-sources` stack fails on `FederationProvisionerLfAdmin`** with an access-denied error from `PutDataLakeSettings`: the account already has LF admins and `lf_admin_role_arn` was not supplied. Re-deploy with it set. Note the failure is at **deploy** time — you will not reach a scan.
+
+If you must recover an already-failed deploy without `lf_admin_role_arn`, use `--no-rollback` so the caller role survives with a stable ARN, register it, then deploy again:
 
 ```bash
-ROLE_ARN=$(aws ssm get-parameter --name "/{prefix}/sources/federation-provisioner-role-arn" \
-  --query Parameter.Value --output text)
-# Merge $ROLE_ARN into the existing DataLakeAdmins, then write them back:
+cdk deploy coa-dev-sources --no-rollback
+aws cloudformation describe-stack-resources --stack-name coa-dev-sources \
+  --query "StackResources[?contains(LogicalResourceId,'FederationProvisionerLfAdminOnEventServiceRole')].PhysicalResourceId" \
+  --output text
+# Merge that role into the existing DataLakeAdmins as a current admin, then re-deploy.
 aws lakeformation get-data-lake-settings
 aws lakeformation put-data-lake-settings --data-lake-settings '{ ...existing settings..., \
-  "DataLakeAdmins": [ ...existing admins..., {"DataLakePrincipalIdentifier": "'"$ROLE_ARN"'"} ] }'
+  "DataLakeAdmins": [ ...existing admins..., {"DataLakePrincipalIdentifier": "<caller-role-arn>"} ] }'
 ```
+
+**Troubleshooting — `CreateCatalog` fails with `Insufficient Lake Formation permission(s): Required Create Catalog on Catalog`:** the provisioner role is not an LF data-lake admin, i.e. the custom resource never succeeded. This is a Lake Formation authorization error, **not** IAM — adding `glue:CreateCatalog` / `lakeformation:*` to the role's IAM policy will not fix it. Confirm the sources stack deployed cleanly, then re-trigger the scan.
+
+**What COA changes about your LF posture:** existing admins and all other settings (including the `IAM_ALLOWED_PRINCIPALS` defaults that make LF defer to IAM) are round-tripped untouched — COA does not flip an account into strict LF mode. But on a greenfield account the first deploy takes `DataLakeAdmins` from empty to non-empty, after which LF enforces admin-only access to settings; any principal that previously managed LF settings via IAM permission alone loses that ability until it is added as an admin. `cdk destroy` deregisters the principal COA registered.
 
 The provisioning step is fatal, so a failed run marks the scan `FAILED` and the source `SCAN_FAILED`. After granting admin, re-trigger a scan on the affected source to retry. A failed attempt may leave an orphaned Glue connection (`{prefix}ds_*`); on retry it is reused via the handled `AlreadyExistsException`, or it can be deleted manually once it leaves the in-progress state.
 

--- a/infra/lib/constructs/lakeformation-admin.ts
+++ b/infra/lib/constructs/lakeformation-admin.ts
@@ -21,6 +21,27 @@ export interface LakeFormationAdminProps {
    * the handler still reads the authoritative value from SSM at runtime.
    */
   readonly roleArn: string;
+  /**
+   * ARN of a role that is ALREADY a Lake Formation data-lake admin, to run the
+   * onEvent Lambda as. Brownfield bootstrap escape hatch.
+   *
+   * `PutDataLakeSettings` may only be called by an existing data-lake admin once
+   * an account has any admins, and the caller is this construct's Lambda role.
+   * Left unset, that role is created by this deployment and auto-named, so the
+   * documented "register it as an LF admin before the first deploy" is circular:
+   * there is nothing to register until the deploy that needs it has already run,
+   * and a rollback deletes it and re-creates it under a new name on retry.
+   *
+   * Supplying a role you already own and have already registered breaks the
+   * cycle — registration happens once, out-of-band, against a stable ARN,
+   * before any COA deployment. Greenfield accounts (zero admins) do not need
+   * this: LF has no admin to enforce, so the auto-created role self-bootstraps.
+   *
+   * The role must be assumable by `lambda.amazonaws.com`. This construct
+   * attaches the permissions it needs (LF settings read/write, one SSM
+   * parameter read, CloudWatch Logs) to it, so it is imported as mutable.
+   */
+  readonly existingAdminRoleArn?: string;
 }
 
 /**
@@ -32,9 +53,10 @@ export interface LakeFormationAdminProps {
  * admins and other settings. Removes the role on stack deletion (best-effort).
  *
  * NOTE: `PutDataLakeSettings` requires the caller (this construct's Lambda role)
- * to already be an LF data-lake admin once any admins exist. In a greenfield
- * account (no admins) it self-bootstraps; in an account that already has admins,
- * add `adminLambdaRole` as an LF admin once, out-of-band, before first deploy.
+ * to already be an LF data-lake admin once any admins exist. Greenfield accounts
+ * (no admins) self-bootstrap. Accounts that already have admins must supply
+ * {@link LakeFormationAdminProps.existingAdminRoleArn} — see that prop for why
+ * registering the auto-created role "before first deploy" cannot work.
  */
 export class LakeFormationAdmin extends Construct {
   /** Execution role of the onEvent Lambda — must be an LF admin to write settings. */
@@ -43,6 +65,40 @@ export class LakeFormationAdmin extends Construct {
   constructor(scope: Construct, id: string, props: LakeFormationAdminProps) {
     super(scope, id);
 
+    // Imported mutable (the default) so the addToRolePolicy calls below attach
+    // to it: a caller-supplied role is expected to be an LF admin, not to have
+    // guessed the exact IAM statements this handler needs.
+    //
+    // Rejected at synth if not same-account, because CDK silently imports a
+    // cross-account role as IMMUTABLE — every policy attachment below would
+    // become a no-op and the deploy would instead fail at runtime on an
+    // unrelated-looking AccessDenied against SSM. Lambda cannot use a
+    // cross-account execution role anyway, so nothing valid is being rejected.
+    if (
+      props.existingAdminRoleArn &&
+      !cdk.Token.isUnresolved(props.existingAdminRoleArn)
+    ) {
+      const { account } = cdk.Stack.of(this);
+      const arnAccount = cdk.Arn.split(
+        props.existingAdminRoleArn,
+        cdk.ArnFormat.SLASH_RESOURCE_NAME,
+      ).account;
+      if (!cdk.Token.isUnresolved(account) && arnAccount !== account) {
+        throw new Error(
+          `existingAdminRoleArn must be a role in this account (${account}), got ` +
+            `${props.existingAdminRoleArn}. Lambda cannot assume a cross-account ` +
+            "execution role, and CDK would import it as immutable.",
+        );
+      }
+    }
+    const suppliedRole = props.existingAdminRoleArn
+      ? iam.Role.fromRoleArn(
+          this,
+          "SuppliedAdminRole",
+          props.existingAdminRoleArn,
+        )
+      : undefined;
+
     const onEvent = new lambda.Function(this, "OnEvent", {
       runtime: lambda.Runtime.PYTHON_3_12,
       handler: "index.handler",
@@ -50,8 +106,37 @@ export class LakeFormationAdmin extends Construct {
       code: lambda.Code.fromAsset(
         path.join(__dirname, "../lambdas/lakeformation-admin"),
       ),
+      ...(suppliedRole && { role: suppliedRole }),
     });
     this.adminLambdaRole = onEvent.role!;
+
+    // Passing an explicit `role` suppresses CDK's default basic-execution
+    // attachment, so the handler's warning logs (the only signal on a
+    // best-effort Delete failure) would silently go nowhere.
+    //
+    // Granted as an inline statement, NOT via addManagedPolicy: on an imported
+    // role the latter is a silent no-op — CDK emits no resource for it, because
+    // it does not own the role and cannot rewrite its ManagedPolicyArns. This
+    // path emits an AWS::IAM::Policy attached to the role by name, which does.
+    if (suppliedRole) {
+      suppliedRole.addToPrincipalPolicy(
+        new iam.PolicyStatement({
+          actions: [
+            "logs:CreateLogGroup",
+            "logs:CreateLogStream",
+            "logs:PutLogEvents",
+          ],
+          resources: [
+            cdk.Stack.of(this).formatArn({
+              service: "logs",
+              resource: "log-group",
+              resourceName: "/aws/lambda/*",
+              arnFormat: cdk.ArnFormat.COLON_RESOURCE_NAME,
+            }),
+          ],
+        }),
+      );
+    }
 
     // LF settings APIs do not support resource-level scoping.
     onEvent.addToRolePolicy(

--- a/infra/lib/stacks/foundation/storage-stack.ts
+++ b/infra/lib/stacks/foundation/storage-stack.ts
@@ -148,7 +148,8 @@ export class StorageStack extends SCLStack {
     // - NEXTGEN generation: 2x indexing throughput, sub-100ms p99 search latency
     // - Standby replicas: must be ENABLED for NEXTGEN (AWS rejects DISABLED).
     //   NEXTGEN strict mode rejects knn_vector method blocks — catches regressions.
-    // - Capacity limits: min 1 OCU (lowest valid), max 96 OCU (cost cap)
+    // - Capacity limits: min 2 OCU (default, override via `aoss_min_ocu`; set 0
+    //   for NextGen scale-to-zero), max 96 OCU (cost cap)
     //
     // BREAKING CHANGE: Collection renamed to {prefix}-vector-store.
     // This creates a new collection — existing vector embeddings must be re-ingested

--- a/infra/lib/stacks/services/sources-stack.ts
+++ b/infra/lib/stacks/services/sources-stack.ts
@@ -743,14 +743,18 @@ export class SourcesStack extends SCLStack {
     // Register the federation provisioner role as an LF data-lake admin
     // non-destructively (read current admins → append → write), instead of the
     // declarative CfnDataLakeSettings which would overwrite existing admins.
-    // See LakeFormationAdmin for the bootstrap caveat (the CR Lambda role must
-    // itself be an LF admin in accounts that already have admins).
+    // Accounts that already have LF admins must supply `lf_admin_role_arn`
+    // (a role already registered as an admin) — see LakeFormationAdmin.
+    const lfAdminRoleArn = this.node.tryGetContext("lf_admin_role_arn") as
+      | string
+      | undefined;
     const lfAdmin = new LakeFormationAdmin(
       this,
       "FederationProvisionerLfAdmin",
       {
         roleArnSsmParameterName: `${ssmPrefix}/sources/federation-provisioner-role-arn`,
         roleArn: fedFnRole.roleArn,
+        ...(lfAdminRoleArn && { existingAdminRoleArn: lfAdminRoleArn }),
       },
     );
     lfAdmin.node.addDependency(fedRoleArnParam);
@@ -1102,7 +1106,10 @@ export class SourcesStack extends SCLStack {
       "dbScanEnrichmentTimeoutMinutes",
     );
     const enrichmentTimeoutMinutes = Number(enrichmentTimeoutMinutesRaw ?? 120);
-    if (!Number.isFinite(enrichmentTimeoutMinutes) || enrichmentTimeoutMinutes <= 0) {
+    if (
+      !Number.isFinite(enrichmentTimeoutMinutes) ||
+      enrichmentTimeoutMinutes <= 0
+    ) {
       throw new Error(
         `dbScanEnrichmentTimeoutMinutes must be a positive number, got: ${String(enrichmentTimeoutMinutesRaw)}`,
       );

--- a/infra/test/services/sources-stack.test.ts
+++ b/infra/test/services/sources-stack.test.ts
@@ -624,17 +624,16 @@ describe("SourcesStack", () => {
             status: ["TIMED_OUT", "ABORTED", "FAILED"],
           }),
         }),
-        Targets: Match.arrayWith([
-          Match.objectLike({ Arn: Match.anyValue() }),
-        ]),
+        Targets: Match.arrayWith([Match.objectLike({ Arn: Match.anyValue() })]),
       });
     });
 
     it("scopes the reaper rule to the db-scan state machine ARN", () => {
       // The rule must fire only for the db-scan pipeline, not any state machine.
       const rules = template.findResources("AWS::Events::Rule");
-      const reaperRule = Object.values(rules).find((r: any) =>
-        r.Properties?.EventPattern?.detail?.stateMachineArn !== undefined,
+      const reaperRule = Object.values(rules).find(
+        (r: any) =>
+          r.Properties?.EventPattern?.detail?.stateMachineArn !== undefined,
       ) as any;
       expect(reaperRule).toBeDefined();
       expect(
@@ -655,7 +654,11 @@ describe("SourcesStack", () => {
         env: TEST_ENV,
       });
       return Template.fromStack(
-        new SourcesStack(app, "CtxSources", { network, storage, env: TEST_ENV }),
+        new SourcesStack(app, "CtxSources", {
+          network,
+          storage,
+          env: TEST_ENV,
+        }),
       );
     };
 
@@ -672,9 +675,9 @@ describe("SourcesStack", () => {
     });
 
     it("rejects a non-positive / non-numeric dbScanEnrichmentTimeoutMinutes at synth", () => {
-      expect(() => synthWithContext({ dbScanEnrichmentTimeoutMinutes: 0 })).toThrow(
-        /dbScanEnrichmentTimeoutMinutes must be a positive number/,
-      );
+      expect(() =>
+        synthWithContext({ dbScanEnrichmentTimeoutMinutes: 0 }),
+      ).toThrow(/dbScanEnrichmentTimeoutMinutes must be a positive number/);
       expect(() =>
         synthWithContext({ dbScanEnrichmentTimeoutMinutes: "abc" }),
       ).toThrow(/dbScanEnrichmentTimeoutMinutes must be a positive number/);
@@ -937,5 +940,117 @@ describe("SourcesStack", () => {
         }
       });
     }
+  });
+});
+
+/**
+ * Brownfield Lake Formation bootstrap.
+ *
+ * `PutDataLakeSettings` may only be called by an existing data-lake admin once an
+ * account has any admins, and the caller is the LakeFormationAdmin custom
+ * resource's own Lambda role. Auto-created, that role does not exist until the
+ * deploy that needs it has already run — and a rollback deletes it and re-creates
+ * it under a new auto-generated name, invalidating any registration made against
+ * the previous ARN. `lf_admin_role_arn` lets an operator supply a role that is
+ * already an admin, so registration happens once against a stable ARN.
+ */
+describe("SourcesStack — Lake Formation admin caller role", () => {
+  const SUPPLIED_ROLE_ARN = "arn:aws:iam::123456789012:role/existing-lf-admin";
+
+  function templateWith(extraContext: Record<string, unknown>): Template {
+    const app = new cdk.App({ context: { ...TEST_CONTEXT, ...extraContext } });
+    const network = new NetworkStack(app, "TestNetwork", { env: TEST_ENV });
+    const storage = new StorageStack(app, "TestStorage", {
+      network,
+      env: TEST_ENV,
+    });
+    return Template.fromStack(
+      new SourcesStack(app, "TestSources", {
+        network,
+        storage,
+        allowedOrigin: "https://test.example.com",
+        env: TEST_ENV,
+      }),
+    );
+  }
+
+  /** The onEvent Lambda of the LakeFormationAdmin custom resource. */
+  function lfAdminOnEventRole(template: Template): unknown {
+    const fns = template.findResources("AWS::Lambda::Function");
+    const match = Object.entries(fns).find(([logicalId]) =>
+      logicalId.includes("FederationProvisionerLfAdminOnEvent"),
+    );
+    expect(match).toBeDefined();
+    return match![1].Properties.Role;
+  }
+
+  it("runs the custom resource as the supplied role when lf_admin_role_arn is set", () => {
+    const template = templateWith({ lf_admin_role_arn: SUPPLIED_ROLE_ARN });
+
+    // The literal ARN, not a GetAtt at a role this stack created — that is the
+    // whole point: the ARN is stable and registerable before the first deploy.
+    expect(lfAdminOnEventRole(template)).toEqual(SUPPLIED_ROLE_ARN);
+  });
+
+  it("still grants the supplied role LF settings access and Lambda logging", () => {
+    const template = templateWith({ lf_admin_role_arn: SUPPLIED_ROLE_ARN });
+
+    // A caller-supplied role is expected to be an LF admin, not to have guessed
+    // the IAM statements the handler needs, so the construct attaches them.
+    template.hasResourceProperties("AWS::IAM::Policy", {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: Match.arrayWith([
+              "lakeformation:GetDataLakeSettings",
+              "lakeformation:PutDataLakeSettings",
+            ]),
+          }),
+        ]),
+      },
+      Roles: Match.arrayWith(["existing-lf-admin"]),
+    });
+
+    // Passing an explicit role suppresses CDK's default basic-execution
+    // attachment, which would silently drop the handler's warning logs. Granted
+    // inline rather than as a managed policy: addManagedPolicy on an IMPORTED
+    // role emits no resource at all, so this assertion is what catches a
+    // regression back to that silent no-op.
+    template.hasResourceProperties("AWS::IAM::Policy", {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: Match.arrayWith(["logs:PutLogEvents"]),
+          }),
+        ]),
+      },
+      Roles: Match.arrayWith(["existing-lf-admin"]),
+    });
+  });
+
+  it("rejects a cross-account lf_admin_role_arn at synth", () => {
+    // CDK imports a cross-account role as immutable, so the permission
+    // attachments would silently no-op and the failure would surface at deploy
+    // time as an unrelated-looking AccessDenied on SSM. Fail loudly instead.
+    expect(() =>
+      templateWith({
+        lf_admin_role_arn: "arn:aws:iam::999988887777:role/foreign-lf-admin",
+      }),
+    ).toThrow(/must be a role in this account/);
+  });
+
+  it("auto-creates the caller role when lf_admin_role_arn is absent (greenfield self-bootstrap)", () => {
+    const template = templateWith({});
+
+    // Greenfield accounts have no admin for LF to enforce, so the auto-created
+    // role can register itself — no operator action required.
+    expect(lfAdminOnEventRole(template)).toEqual({
+      "Fn::GetAtt": [
+        expect.stringContaining(
+          "FederationProvisionerLfAdminOnEventServiceRole",
+        ),
+        "Arn",
+      ],
+    });
   });
 });

--- a/packages/context-manager/docs/query-routing.md
+++ b/packages/context-manager/docs/query-routing.md
@@ -65,7 +65,7 @@ Matching is exact (after normalization). The resolver returns a `MetricMatch` wi
 
 ## Tier 2 retrieval
 
-Tier 2 embeds the query (via Bedrock Titan Embed) and does a k-NN search over the
+Tier 2 embeds the query (via Bedrock Cohere Embed v4) and does a k-NN search over the
 `semantic_entities_{namespace_short_id}` OpenSearch index to select the relevant
 ontology classes/properties for the NL→SQL/SPARQL prompt. The generated SQL/SPARQL
 is then translated (Ontop VKG) and executed. Tier 2 produces a result only over

--- a/packages/metric-service/README.md
+++ b/packages/metric-service/README.md
@@ -105,7 +105,7 @@ packages/metric-service/
 │   │   └── export_osi.py            # GET /export-osi
 │   ├── validator.py                   # 6-check validation engine
 │   ├── neptune_client.py             # SPARQL CRUD (SigV4 + httpx)
-│   ├── opensearch_client.py          # Vector embeddings (Bedrock Titan + AOSS)
+│   ├── opensearch_client.py          # Vector embeddings (Bedrock Cohere Embed v4 + AOSS)
 │   ├── osi_parser.py                 # OSI v1.0 YAML parse/serialize
 │   ├── dataset_resolver.py           # Resolve OSI datasets → data sources
 │   ├── metadata_reconciler.py        # Additive metadata merge
@@ -305,7 +305,8 @@ non-blocking `warnings` on the `201`/`200` response body.
 | `IMPORT_QUEUE_URL` | Yes | SQS URL for async import messages |
 | `IMPORT_JOBS_TABLE` | Yes | DynamoDB table for import job tracking |
 | `EVENTBRIDGE_BUS_NAME` | No | EventBridge bus name (default: `default`) |
-| `BEDROCK_MODEL_ID` | No | Embedding model (default: `amazon.titan-embed-text-v2:0`) |
+| `BEDROCK_EMBED_MODEL_ID` | No | Embedding model. Takes precedence over `BEDROCK_MODEL_ID` (default: `DEFAULT_EMBED_MODEL_ID` — `us.cohere.embed-v4:0`) |
+| `BEDROCK_MODEL_ID` | No | Embedding model, legacy fallback name (default: `DEFAULT_EMBED_MODEL_ID` — `us.cohere.embed-v4:0`) |
 | `OSS_INDEX_PREFIX` | No | OpenSearch index name prefix — shared with ontology-engine (default: `ontology-workbench-embeddings`) |
 | `OSS_DIMENSIONS` | No | Embedding vector dimensions (default: `1024`) |
 | `ALLOWED_ORIGIN` | No | CORS allowed origin |
@@ -369,9 +370,17 @@ Neptune auth uses SigV4 via `botocore.auth` + `httpx`.
 
 ### OpenSearch (AOSS)
 
-Metrics are embedded using Bedrock Titan Text Embeddings V2 and stored in the
+Metrics are embedded using Bedrock Cohere Embed v4 (1024-dim) and stored in the
 shared ontology vector index (same index as ontology-engine classes/properties),
 using `ontology_vector_index_name(OSS_INDEX_PREFIX, namespace)`.
+
+The model is **not** configured here — it comes from
+`coa_common.constants.DEFAULT_EMBED_MODEL_ID`, the single source of truth shared
+by every embedding producer and consumer. Every writer to this index must use the
+same model or the vectors are cross-model incomparable and retrieval silently
+degrades to noise. Note that Cohere Embed v4 and the previously-used Titan Text
+Embeddings V2 are both 1024-dim, so a mismatch does not fail loudly — it just
+returns bad neighbours.
 
 Document schema conforms to the ontology-engine's mapping:
 ```json
@@ -380,7 +389,7 @@ Document schema conforms to the ontology-engine's mapping:
   "ontology_id": "urn:coa:vocab#GovernedMetrics",
   "entity_type": "metric",
   "embedding_type": "lexical",
-  "model_id": "amazon.titan-embed-text-v2:0",
+  "model_id": "us.cohere.embed-v4:0",
   "namespace": "{ns}",
   "text": "name description synonyms instructions examples",
   "embedding": [1024-dim vector]

--- a/packages/ontology-engine/README.md
+++ b/packages/ontology-engine/README.md
@@ -7,7 +7,7 @@
 Automated induction of OWL 2 ontologies from relational schemas and
 unstructured documents. Grounds against foundational ontologies
 (Schema.org, Dublin Core, PROV-O, FOAF, FIBO) via vector similarity
-(Amazon Bedrock Titan Text Embeddings V2). Uses large language models
+(Amazon Bedrock Cohere Embed v4). Uses large language models
 (Amazon Bedrock Claude) for concept extraction, alignment, and
 rigor-style generate/judge induction. Persists ontologies and
 embeddings in Amazon Neptune Analytics (graph + HNSW vector index) or
@@ -232,7 +232,7 @@ list):
 - [R2RML — RDB to RDF Mapping Language](https://www.w3.org/TR/r2rml/)
 - [SKOS Simple Knowledge Organization System](https://www.w3.org/TR/skos-reference/)
 - [Amazon Neptune Analytics Vector Search](https://docs.aws.amazon.com/neptune-analytics/latest/userguide/vector-search.html)
-- [Amazon Bedrock Titan Text Embeddings V2](https://docs.aws.amazon.com/bedrock/latest/userguide/titan-embedding-models.html)
+- [Cohere Embed v4 on Amazon Bedrock](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html)
 - Nayyeri et al., [RIGOR: Retrieval-Augmented Generation of Ontologies](https://arxiv.org/abs/2506.01232), 2025
 - Sequeda et al., [A Benchmark to Understand the Role of Knowledge Graphs on LLM's Accuracy for QA on Enterprise SQL Databases](https://arxiv.org/abs/2311.07509), 2023
 - Tartir et al., OntoQA: Metric-Based Ontology Quality Analysis, 2005


### PR DESCRIPTION
## Problem

Accounts that already have Lake Formation data-lake admins **cannot deploy the sources stack at all**.

`PutDataLakeSettings` may only be called by an existing data-lake admin once an account has any, and the caller is the `LakeFormationAdmin` custom resource's own Lambda role. That role was always auto-created and auto-named, which made the documented remedy — "register it as an LF admin before the first deploy" — circular: there is nothing to register until the deploy that needs it has already failed. The rollback then deletes the role and re-creates it under a new random-suffixed name on retry, invalidating any registration made against the previous ARN.

Two related things the docs got wrong, both reported by a customer:

- The failure was described as "JDBC scans fail at `CreateCatalog`". It actually fails **at deploy time** on `coa-<env>-sources`; no scan ever runs.
- Registering the *federation provisioner* role from SSM was suggested as the fix. That is the role being **registered**, not the one **making the call**, so it does not help.

## Change

New `lf_admin_role_arn` CDK context variable runs the custom resource as a role the operator already owns and has already registered as an admin, so the call is authorized on the first deploy:

```bash
cdk deploy coa-dev-sources -c lf_admin_role_arn=arn:aws:iam::<account>:role/<your-lf-admin>
```

The construct attaches the IAM permissions the handler needs (LF settings read/write, one SSM parameter read, CloudWatch Logs) to the supplied role, so it does not need them beforehand. Greenfield accounts are unchanged — with zero admins LF has nothing to enforce and the auto-created role still self-bootstraps.

Two non-obvious details, both verified by synthesizing rather than by reasoning:

- **Logging is granted inline, not via `addManagedPolicy`.** On an *imported* role `addManagedPolicy` is a silent no-op — CDK emits no resource for it, since it does not own the role and cannot rewrite `ManagedPolicyArns`. Left that way, the handler's warning logs (the only signal on a best-effort `Delete` failure) would have gone nowhere. A test pins this.
- **A cross-account ARN is rejected at synth.** CDK imports such a role as immutable, so every permission attachment would silently no-op and the deploy would fail later on an unrelated-looking `AccessDenied` against SSM. Lambda cannot use a cross-account execution role anyway, so nothing valid is rejected.

## Docs corrected alongside

Three documentation defects, all found while answering the same customer:

- **LF bootstrap** (`getting-started.md`, `infra/README.md`) — now distinguishes the two roles in a table, states that the failure lands at deploy time, and drops the impossible "register before first deploy" instruction. Adds a *what COA changes about your Lake Formation posture* section: existing admins and the `IAM_ALLOWED_PRINCIPALS` defaults are preserved (COA does not flip an account into strict LF mode), but a greenfield account's first deploy takes `DataLakeAdmins` from empty to non-empty, after which any principal that previously managed LF settings through IAM permission alone loses that ability until it is added as an admin.
- **`aoss_min_ocu`** — documented as defaulting to `0` while the code ships `2`, so the docs promised a scale-to-zero idle cost floor that no deployment actually got. Table now matches the code, with a new section on opting into `0` and the 429 / cold-start tradeoff. Also corrects a stale in-code comment claiming min 1 OCU was the lowest valid NextGen value — three sources in the repo disagreed with each other.
- **Embedding model** — the metric-service and ontology-engine READMEs (plus the Tier-2 query-routing doc) still named Titan Text Embeddings V2. Every producer resolves `DEFAULT_EMBED_MODEL_ID`, which is Cohere Embed v4. Notes that both models are 1024-dim, which is why the drift never failed loudly: a mismatch degrades retrieval to noise instead of erroring.

No functional change to the ontology, serve, or embedding paths — the model was already Cohere v4 everywhere in code.

## Observation step

On an account with **pre-existing** LF admins:

```bash
cdk deploy coa-dev-sources -c lf_admin_role_arn=arn:aws:iam::<acct>:role/<admin>
aws lakeformation get-data-lake-settings
```

Expect the stack to reach `CREATE_COMPLETE` with `FederationProvisionerLfAdmin` succeeding, and `DataLakeAdmins` to contain **both** the pre-existing admins and the federation provisioner role.

Without the flag on the same account, expect the stack to fail on that custom resource with an `AccessDenied` from `PutDataLakeSettings` — confirming the guard is what unblocks it.

Unit level:

```bash
npx jest test/services/sources-stack.test.ts -t "Lake Formation admin caller role"
```

Expect 4 passing: supplied-role wiring, permission attachment, cross-account synth rejection, greenfield auto-create.

## Testing

- `npx jest --runInBand` — 427 passed, 28 suites (4 new).
- `uv run pytest test/lambdas -q` — 33 passed.
- `npm run lint` (tsc --noEmit + ruff check + ruff format --check) — clean.
- Prettier clean.

Note: a fresh worktree needs `make generate` before the infra tests run, since `api-stack.test.ts` reads the generated OpenAPI spec.

## Not addressed

The customer also asked about a private-only deployment mode that skips CloudFront (`enablePrivateEndpoints` currently throws "not yet implemented"). Out of scope here and tracked separately.