### PR TITLE
fix(tests): skip VKG-publish barrier unit test when tests/integ is stripped

### DIFF
--- a/packages/ontology-engine/tests/unit/test_integ_vkg_publish_barrier.py
+++ b/packages/ontology-engine/tests/unit/test_integ_vkg_publish_barrier.py
@@ -25,6 +25,9 @@ pytestmark = pytest.mark.unit
 
 _MODULE_PATH = Path(__file__).resolve().parents[1] / "integ" / "test_accept_ontology_components.py"
 
+if not _MODULE_PATH.exists():
+    pytest.skip("tests/integ/ is absent or incomplete in this checkout (public mirror)", allow_module_level=True)
+
 
 @pytest.fixture(scope="module")
 def mod():

--- a/tests/unit/test_mirror_paths.py
+++ b/tests/unit/test_mirror_paths.py
@@ -78,8 +78,9 @@ def test_guarded_makefile_targets_do_not_fail_on_missing_dirs(target: str) -> No
 
 
 # `tests/unit/` is mirrored publicly; every other `tests/` subdirectory is not (see
-# the allowlist in .npmignore). Matches the `_REPO_ROOT / "tests" / "cdk"` idiom.
-_UNMIRRORED_TESTS_REF = re.compile(r'"tests"\s*/\s*"(?!unit)')
+# the allowlist in .npmignore). Matches the `_REPO_ROOT / "tests" / "cdk"` idiom, plus
+# the shorter `Path(__file__).parents[1] / "integ"` form that names no "tests" segment.
+_UNMIRRORED_TESTS_REF = re.compile(r'"tests"\s*/\s*"(?!unit)|/\s*"(?:integ|cdk)"')
 
 
 def _mirrored_unit_test_files() -> list[Path]:


### PR DESCRIPTION
Unblocks the `unit-test` job on #142.

## Problem

`ontology-engine:test` is the only failing task on #142 (everything else — 1452 sources tests, web-app, control-plane, infra, lint, cdk-synth — is green). Four errors, all identical, at fixture setup:

```
E FileNotFoundError: [Errno 2] No such file or directory:
  '.../packages/ontology-engine/tests/integ/test_accept_ontology_components.py'
```

`packages/ontology-engine/tests/unit/test_integ_vkg_publish_barrier.py` covers `_wait_for_vkg_publish`, which lives in the integ suite, so it loads that module by path (the integ dir is not an importable package). `.npmignore` strips `**/tests/integ/` from the public mirror, so the unit test ships but the file it reads does not, and the module-scoped fixture raises for all four tests.

Not specific to #142 — the previous mirror sync (run `33816565930`, Sept 3) failed with the identical error. Internally `tests/integ/` is present, so the test passes there and the breakage is invisible to the internal pipeline.

## Change

1. `test_integ_vkg_publish_barrier.py` — module-level existence guard, verbatim the idiom already used by `packages/context-manager/tests/unit/test_integ_provision_cli.py`:

```python
if not _MODULE_PATH.exists():
    pytest.skip("tests/integ/ is absent or incomplete in this checkout (public mirror)", allow_module_level=True)
```

2. `tests/unit/test_mirror_paths.py` — root cause of why CI let this through. The repo already has a guard test for this exact class of bug (`test_unit_tests_reaching_outside_tests_unit_skip_when_the_path_is_absent`), but its detector only matched the `"tests" / "integ"` spelling. This test writes `parents[1] / "integ"`, naming no `"tests"` segment, so it was invisible. The regex now also matches a bare `/ "integ"` or `/ "cdk"` segment, so the next short-form reference is caught pre-merge rather than after it reaches the mirror.

## Observation step

On this branch (mirror content, `tests/integ/` genuinely absent):

```
cd packages/ontology-engine && pytest tests/unit/test_integ_vkg_publish_barrier.py -q -rs
```

Expect `1 skipped` with reason `tests/integ/ is absent or incomplete in this checkout (public mirror)`, instead of four `FileNotFoundError` errors. Then `pytest tests/unit -q` from the repo root — expect `77 passed, 4 skipped`, and the `unit-test` job on this PR to go green.

Also verified in an internal checkout, where `tests/integ/` exists:

- `pytest packages/ontology-engine/tests/unit/test_integ_vkg_publish_barrier.py` → 4 passed (behavior unchanged where the fixture is present).
- `pytest packages/ontology-engine/tests/unit` → 2081 passed, 1 skipped.
- `pytest tests/unit` → 102 passed. Reverting only change 1 makes `test_mirror_paths.py` fail and name the offending file, confirming the broadened detector would have caught this.
- `make generate && pnpm i && make lint` → clean for all 12 projects.

## Notes

Test-only change; no src, infra, or Smithy model touched. Base is the mirror-sync branch rather than `main` so the diff stays at two files — a branch based on internal `main` would show every mirror-stripped path as an addition.

The same commit is staged internally on `fix/mirror-integ-guard`; it needs to land there too, or the next mirror sync regenerates the breakage.